### PR TITLE
CMS Signing support

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(X509
   "CryptographicMessageSyntax/CMSContentInfo.swift"
   "CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift"
   "CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift"
+  "CryptographicMessageSyntax/CMSOperations.swift"
   "CryptographicMessageSyntax/CMSSignedData.swift"
   "CryptographicMessageSyntax/CMSSignerIdentifier.swift"
   "CryptographicMessageSyntax/CMSSignerInfo.swift"

--- a/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
@@ -15,6 +15,16 @@
 import SwiftASN1
 
 extension ASN1ObjectIdentifier {
+    /// Cryptographic Message Syntax (CMS) Data.
+    ///
+    /// ASN.1 definition:
+    /// ```
+    /// id-data OBJECT IDENTIFIER ::= { iso(1) member-body(2)
+    ///    us(840) rsadsi(113549) pkcs(1) pkcs7(7) 1 }
+    /// ```
+    @usableFromInline
+    static let cmsData: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 7, 1]
+
     /// Cryptographic Message Syntax (CMS) Signed Data.
     ///
     /// ASN.1 definition:
@@ -22,6 +32,7 @@ extension ASN1ObjectIdentifier {
     /// id-signedData OBJECT IDENTIFIER ::= { iso(1) member-body(2)
     ///    us(840) rsadsi(113549) pkcs(1) pkcs7(7) 2 }
     /// ```
+    @usableFromInline
     static let cmsSignedData: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 7, 2]
 }
 
@@ -32,19 +43,26 @@ extension ASN1ObjectIdentifier {
 ///   content [0] EXPLICIT ANY DEFINED BY contentType }
 /// ContentType ::= OBJECT IDENTIFIER
 /// ```
+@usableFromInline
 struct CMSContentInfo: DERImplicitlyTaggable, Hashable {
+    @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
-    
+
+    @usableFromInline
     var contentType: ASN1ObjectIdentifier
+
+    @usableFromInline
     var content: ASN1Any
-    
+
+    @inlinable
     init(contentType: ASN1ObjectIdentifier, content: ASN1Any) {
         self.contentType = contentType
         self.content = content
     }
-    
+
+    @inlinable
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in
             let contentType = try ASN1ObjectIdentifier(derEncoded: &nodes)
@@ -56,6 +74,7 @@ struct CMSContentInfo: DERImplicitlyTaggable, Hashable {
         }
     }
 
+    @inlinable
     func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier) { coder in
             try coder.serialize(contentType)
@@ -67,11 +86,13 @@ struct CMSContentInfo: DERImplicitlyTaggable, Hashable {
 }
 
 extension CMSContentInfo {
+    @inlinable
     init(_ signedData: CMSSignedData) throws {
         self.contentType = .cmsSignedData
         self.content = try ASN1Any(erasing: signedData)
     }
-    
+
+    @inlinable
     var signedData: CMSSignedData? {
         get throws {
             guard contentType == .cmsSignedData else {

--- a/Sources/X509/CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift
@@ -21,19 +21,26 @@ import SwiftASN1
 ///   eContent [0] EXPLICIT OCTET STRING OPTIONAL }
 /// ContentType ::= OBJECT IDENTIFIER
 /// ```
+@usableFromInline
 struct CMSEncapsulatedContentInfo: DERImplicitlyTaggable, Hashable {
+    @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
-    
+
+    @usableFromInline
     var eContentType: ASN1ObjectIdentifier
+
+    @usableFromInline
     var eContent: ASN1OctetString?
-    
+
+    @inlinable
     init(eContentType: ASN1ObjectIdentifier, eContent: ASN1OctetString? = nil) {
         self.eContentType = eContentType
         self.eContent = eContent
     }
-    
+
+    @inlinable
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in
             let eContentType = try ASN1ObjectIdentifier(derEncoded: &nodes)
@@ -44,7 +51,8 @@ struct CMSEncapsulatedContentInfo: DERImplicitlyTaggable, Hashable {
             return .init(eContentType: eContentType, eContent: eContent)
         }
     }
-    
+
+    @inlinable
     func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier, { coder in
             try coder.serialize(eContentType)

--- a/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
@@ -22,14 +22,17 @@ import SwiftASN1
 /// ```
 /// The definition of `Name` is taken from X.501 [X.501-88], and the
 /// definition of `CertificateSerialNumber` is taken from X.509 [X.509-97].
+@usableFromInline
 struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable {
+    @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
     
-    var issuer: DistinguishedName
-    var serialNumber: Certificate.SerialNumber
-    
+    @usableFromInline var issuer: DistinguishedName
+    @usableFromInline var serialNumber: Certificate.SerialNumber
+
+    @inlinable
     init(
         issuer: DistinguishedName,
         serialNumber: Certificate.SerialNumber
@@ -37,7 +40,8 @@ struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable {
         self.issuer = issuer
         self.serialNumber = serialNumber
     }
-    
+
+    @inlinable
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in
             let issuer = try DistinguishedName(derEncoded: &nodes)
@@ -46,6 +50,7 @@ struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable {
         }
     }
 
+    @inlinable
     func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier) { coder in
             try coder.serialize(self.issuer)

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -1,0 +1,222 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import SwiftASN1
+
+public enum CMS {
+    @_spi(CMS)
+    @inlinable
+    public static func sign<Bytes: DataProtocol>(
+        _ bytes: Bytes,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        certificate: Certificate,
+        privateKey: Certificate.PrivateKey
+    ) throws -> [UInt8] {
+        let signature = try privateKey.sign(bytes: bytes, signatureAlgorithm: signatureAlgorithm)
+        return try sign(
+            signatureBytes: ASN1OctetString(signature),
+            signatureAlgorithm: signatureAlgorithm,
+            certificate: certificate
+        )
+    }
+
+    @_spi(CMS)
+    @inlinable
+    public static func sign(
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        certificate: Certificate
+    ) throws -> [UInt8] {
+        let signedData = try self.generateSignedData(signatureBytes: signatureBytes, signatureAlgorithm: signatureAlgorithm, certificate: certificate)
+
+        var serializer = DER.Serializer()
+        try serializer.serialize(signedData)
+        return serializer.serializedBytes
+    }
+
+    @inlinable
+    static func generateSignedData(
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        certificate: Certificate
+    ) throws -> CMSContentInfo {
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        let contentInfo = CMSEncapsulatedContentInfo(eContentType: .cmsData)
+
+        let signerInfo = CMSSignerInfo(
+            signerIdentifier: .init(issuerAndSerialNumber: certificate),
+            digestAlgorithm: digestAlgorithm,
+            signatureAlgorithm: AlgorithmIdentifier(signatureAlgorithm),
+            signature: signatureBytes
+        )
+
+        let signedData = CMSSignedData(
+            version: .v1,
+            digestAlgorithms: [digestAlgorithm],
+            encapContentInfo: contentInfo,
+            certificates: [certificate],
+            signerInfos: [signerInfo]
+        )
+        return try CMSContentInfo(signedData)
+    }
+
+    @_spi(CMS)
+    @inlinable
+    public static func isValidSignature<
+        DataBytes: DataProtocol,
+        SignatureBytes: DataProtocol
+    >(
+        dataBytes: DataBytes,
+        signatureBytes: SignatureBytes,
+        trustRoots: CertificateStore,
+        policy: PolicySet
+    ) async -> SignatureVerificationResult {
+        do {
+            let parsedSignature = try CMSContentInfo(derEncoded: ArraySlice(signatureBytes))
+            guard let signedData = try parsedSignature.signedData else {
+                return .init(invalidCMSBlockReason: "Unable to parse signed data")
+            }
+
+            // We have a bunch of very specific requirements here: in particular, we need to have only one signature. We also only want
+            // to tolerate v1 signatures and detacted signatures.
+            guard signedData.version == .v1, signedData.signerInfos.count == 1, signedData.encapContentInfo.eContentType == .cmsData,
+                  signedData.encapContentInfo.eContent == nil else {
+                return .init(invalidCMSBlockReason: "Invalid signed data: \(signedData)")
+            }
+
+            // This subscript is safe, we confirmed a count of 1 above.
+            let signer = signedData.signerInfos[0]
+
+            // Double-check that the signer included their digest algorithm in the parent set.
+            //
+            // Per RFC 5652 § 5.1:
+            //
+            // > digestAlgorithms is a collection of message digest algorithm
+            // > identifiers.
+            // > ...
+            // > Implementations MAY fail to validate signatures that use a digest
+            // > algorithm that is not included in this set.
+            guard signedData.digestAlgorithms.contains(signer.digestAlgorithm) else {
+                return .init(invalidCMSBlockReason: "Digest algorithm mismatch")
+            }
+
+            // Convert the signature algorithm to confirm we understand it.
+            // We also want to confirm the digest algorithm matches the signature algorithm.
+            let signatureAlgorithm = Certificate.SignatureAlgorithm(algorithmIdentifier: signer.signatureAlgorithm)
+            let expectedDigestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+            guard expectedDigestAlgorithm == signer.digestAlgorithm else {
+                return .init(invalidCMSBlockReason: "Digest and signature algorithm mismatch")
+            }
+
+            // Ok, now we need to find the signer. We expect to find them in the list of certificates provided
+            // in the signature.
+            guard let signingCert = try signedData.certificates?.certificate(signerInfo: signer) else {
+                return .init(invalidCMSBlockReason: "Unable to locate signing certificate")
+            }
+
+            // Ok at this point we've done the cheap stuff and we're fairly confident we have the entity who should have
+            // done the signing. Our next step is to confirm that they did in fact sign the data. For that we have to compute
+            // the digest and validate the signature.
+            let signature = try Certificate.Signature(signatureAlgorithm: signatureAlgorithm, signatureBytes: signer.signature)
+            guard signingCert.publicKey.isValidSignature(signature, for: dataBytes, signatureAlgorithm: signatureAlgorithm) else {
+                return .init(invalidCMSBlockReason: "Invalid signature from signing certificate: \(signingCert)")
+            }
+
+            // Ok, the signature was signed by the private key associated with this cert. Now we need to validate the certificate.
+            // This force-unwrap is safe: we know there are certificates because we've located at least one certificate from this set!
+            let untrustedIntermediates = CertificateStore(signedData.certificates!)
+            var verifier = Verifier(rootCertificates: trustRoots, policy: policy)
+            let result = await verifier.validate(leafCertificate: signingCert, intermediates: untrustedIntermediates)
+
+            switch result {
+            case .validCertificate:
+                return .validSignature(.init(signer: signingCert))
+            case .couldNotValidate(let validationFailures):
+                return .unableToValidateSigner(.init(validationFailures: validationFailures))
+            }
+        } catch {
+            return .invalidCMSBlock(.init(reason: String(describing: error)))
+        }
+    }
+
+    @_spi(CMS)
+    public enum Error: Swift.Error {
+        case incorrectCMSVersionUsed
+    }
+
+    @_spi(CMS)
+    public enum SignatureVerificationResult {
+        case validSignature(Valid)
+        case unableToValidateSigner(SignerValidationFailure)
+        case invalidCMSBlock(InvalidCMSBlock)
+
+        public struct Valid: Hashable {
+            public var signer: Certificate
+
+            @inlinable
+            public init(signer: Certificate) {
+                self.signer = signer
+            }
+        }
+
+        public struct SignerValidationFailure: Hashable, Swift.Error {
+            public var validationFailures: [VerificationResult.PolicyFailure]
+
+            @inlinable
+            public init(validationFailures: [VerificationResult.PolicyFailure]) {
+                self.validationFailures = validationFailures
+            }
+        }
+
+        public struct InvalidCMSBlock: Hashable, Swift.Error {
+            public var reason: String
+
+            @inlinable
+            public init(reason: String){
+                self.reason = reason
+            }
+        }
+
+        @inlinable
+        internal init(invalidCMSBlockReason: String) {
+            self = .invalidCMSBlock(.init(reason: invalidCMSBlockReason))
+        }
+    }
+}
+
+extension Array where Element == Certificate {
+    @usableFromInline
+    func certificate(signerInfo: CMSSignerInfo) throws -> Certificate? {
+        switch signerInfo.signerIdentifier {
+        case .issuerAndSerialNumber(let issuerAndSerialNumber):
+            for cert in self {
+                if cert.issuer == issuerAndSerialNumber.issuer && cert.serialNumber == issuerAndSerialNumber.serialNumber {
+                    return cert
+                }
+            }
+        case .subjectKeyIdentifier:
+            // This is unsupported for now.
+            return nil
+        }
+
+        return nil
+    }
+}
+
+extension Certificate.Signature {
+    @inlinable
+    init(signatureAlgorithm: Certificate.SignatureAlgorithm, signatureBytes: ASN1OctetString) throws {
+        self = try Certificate.Signature(signatureAlgorithm: signatureAlgorithm, signatureBytes: ASN1BitString(bytes: signatureBytes.bytes))
+    }
+}

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -143,7 +143,7 @@ public enum CMS {
             case .validCertificate:
                 return .validSignature(.init(signer: signingCert))
             case .couldNotValidate(let validationFailures):
-                return .unableToValidateSigner(.init(validationFailures: validationFailures))
+                return .unableToValidateSigner(.init(validationFailures: validationFailures, signer: signingCert))
             }
         } catch {
             return .invalidCMSBlock(.init(reason: String(describing: error)))
@@ -173,9 +173,12 @@ public enum CMS {
         public struct SignerValidationFailure: Hashable, Swift.Error {
             public var validationFailures: [VerificationResult.PolicyFailure]
 
+            public var signer: Certificate
+
             @inlinable
-            public init(validationFailures: [VerificationResult.PolicyFailure]) {
+            public init(validationFailures: [VerificationResult.PolicyFailure], signer: Certificate) {
                 self.validationFailures = validationFailures
+                self.signer = signer
             }
         }
 

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
@@ -41,17 +41,20 @@ import SwiftASN1
 ///   otherCert ANY DEFINED BY otherCertFormat }
 /// ```
 /// - Note: At the moment we don't support `crls` (`RevocationInfoChoices`)
+@usableFromInline
 struct CMSSignedData: DERImplicitlyTaggable, Hashable {
+    @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
     
-    var version: CMSVersion
-    var digestAlgorithms: [AlgorithmIdentifier]
-    var encapContentInfo: CMSEncapsulatedContentInfo
-    var certificates: [Certificate]?
-    var signerInfos: [CMSSignerInfo]
-    
+    @usableFromInline var version: CMSVersion
+    @usableFromInline var digestAlgorithms: [AlgorithmIdentifier]
+    @usableFromInline var encapContentInfo: CMSEncapsulatedContentInfo
+    @usableFromInline var certificates: [Certificate]?
+    @usableFromInline var signerInfos: [CMSSignerInfo]
+
+    @inlinable
     init(
         version: CMSVersion,
         digestAlgorithms: [AlgorithmIdentifier],
@@ -65,7 +68,8 @@ struct CMSSignedData: DERImplicitlyTaggable, Hashable {
         self.certificates = certificates
         self.signerInfos = signerInfos
     }
-    
+
+    @inlinable
     init(derEncoded: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(derEncoded, identifier: identifier) { nodes in
             let version = try CMSVersion(rawValue: Int.init(derEncoded: &nodes))
@@ -90,7 +94,8 @@ struct CMSSignedData: DERImplicitlyTaggable, Hashable {
             )
         }
     }
-    
+
+    @inlinable
     func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier) { coder in
             try coder.serialize(version.rawValue)

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
@@ -20,13 +20,16 @@ import SwiftASN1
 ///   issuerAndSerialNumber IssuerAndSerialNumber,
 ///   subjectKeyIdentifier [0] SubjectKeyIdentifier }
 ///  ```
+@usableFromInline
 enum CMSSignerIdentifier: DERParseable, DERSerializable, Hashable {
-    
-    private static let skiIdentifier = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
+
+    @usableFromInline
+    static let skiIdentifier = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
     
     case issuerAndSerialNumber(CMSIssuerAndSerialNumber)
     case subjectKeyIdentifier(SubjectKeyIdentifier)
-    
+
+    @inlinable
     init(derEncoded node: ASN1Node) throws {
         switch node.identifier {
         case CMSIssuerAndSerialNumber.defaultIdentifier:
@@ -39,7 +42,8 @@ enum CMSSignerIdentifier: DERParseable, DERSerializable, Hashable {
             throw ASN1Error.unexpectedFieldType(node.identifier)
         }
     }
-    
+
+    @inlinable
     func serialize(into coder: inout DER.Serializer) throws {
         switch self {
         case .issuerAndSerialNumber(let issuerAndSerialNumber):
@@ -49,5 +53,10 @@ enum CMSSignerIdentifier: DERParseable, DERSerializable, Hashable {
             try subjectKeyIdentifier.keyIdentifier.serialize(into: &coder, withIdentifier: Self.skiIdentifier)
             
         }
+    }
+
+    @inlinable
+    init(issuerAndSerialNumber certificate: Certificate) {
+        self = .issuerAndSerialNumber(.init(issuer: certificate.issuer, serialNumber: certificate.serialNumber))
     }
 }

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -33,20 +33,25 @@ import SwiftASN1
 /// then the `version` MUST be 1.  If the `SignerIdentifier` is `subjectKeyIdentifier`,
 /// then the `version` MUST be 3.
 /// - Note: At the moment we neither support `signedAttrs` (`SignedAttributes`) nor `unsignedAttrs` (`UnsignedAttributes`)
+@usableFromInline
 struct CMSSignerInfo: DERImplicitlyTaggable, Hashable {
+    @usableFromInline
     enum Error: Swift.Error {
         case versionAndSignerIdentifierMismatch(String)
     }
+
+    @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
     
-    var version: CMSVersion
-    var signerIdentifier: CMSSignerIdentifier
-    var digestAlgorithm: AlgorithmIdentifier
-    var signatureAlgorithm: AlgorithmIdentifier
-    var signature: ASN1OctetString
-    
+    @usableFromInline var version: CMSVersion
+    @usableFromInline var signerIdentifier: CMSSignerIdentifier
+    @usableFromInline var digestAlgorithm: AlgorithmIdentifier
+    @usableFromInline var signatureAlgorithm: AlgorithmIdentifier
+    @usableFromInline var signature: ASN1OctetString
+
+    @inlinable
     init(
         signerIdentifier: CMSSignerIdentifier,
         digestAlgorithm: AlgorithmIdentifier,
@@ -64,7 +69,8 @@ struct CMSSignerInfo: DERImplicitlyTaggable, Hashable {
         self.signatureAlgorithm = signatureAlgorithm
         self.signature = signature
     }
-    
+
+    @inlinable
     init(
         version: CMSVersion,
         signerIdentifier: CMSSignerIdentifier,
@@ -78,7 +84,8 @@ struct CMSSignerInfo: DERImplicitlyTaggable, Hashable {
         self.signatureAlgorithm = signatureAlgorithm
         self.signature = signature
     }
-    
+
+    @inlinable
     init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try DER.sequence(rootNode, identifier: identifier) { nodes in
             let version = try CMSVersion(rawValue: Int(derEncoded: &nodes))
@@ -113,7 +120,8 @@ struct CMSSignerInfo: DERImplicitlyTaggable, Hashable {
             )
         }
     }
-    
+
+    @inlinable
     func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier) { coder in
             try coder.serialize(self.version.rawValue)

--- a/Sources/X509/CryptographicMessageSyntax/CMSVersion.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSVersion.swift
@@ -19,18 +19,26 @@ import SwiftASN1
 ///  CMSVersion ::= INTEGER
 ///                 { v0(0), v1(1), v2(2), v3(3), v4(4), v5(5) }
 /// ```
+@usableFromInline
 struct CMSVersion: RawRepresentable, Hashable {
+    @usableFromInline
     var rawValue: Int
+
+    @inlinable
+    init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
     
-    static let v0 = Self(rawValue: 0)
-    static let v1 = Self(rawValue: 1)
-    static let v2 = Self(rawValue: 2)
-    static let v3 = Self(rawValue: 3)
-    static let v4 = Self(rawValue: 4)
-    static let v5 = Self(rawValue: 5)
+    @usableFromInline static let v0 = Self(rawValue: 0)
+    @usableFromInline static let v1 = Self(rawValue: 1)
+    @usableFromInline static let v2 = Self(rawValue: 2)
+    @usableFromInline static let v3 = Self(rawValue: 3)
+    @usableFromInline static let v4 = Self(rawValue: 4)
+    @usableFromInline static let v5 = Self(rawValue: 5)
 }
 
 extension CMSVersion: CustomStringConvertible {
+    @inlinable
     var description: String {
         "CMSv\(rawValue)"
     }

--- a/Sources/X509/Signature.swift
+++ b/Sources/X509/Signature.swift
@@ -144,3 +144,19 @@ extension ASN1BitString {
         }
     }
 }
+
+extension ASN1OctetString {
+    @inlinable
+    init(_ signature: Certificate.Signature) {
+        switch signature.backing {
+        case .p256(let sig):
+            self = ASN1OctetString(contentBytes: ArraySlice(sig.derRepresentation))
+        case .p384(let sig):
+            self = ASN1OctetString(contentBytes: ArraySlice(sig.derRepresentation))
+        case .p521(let sig):
+            self = ASN1OctetString(contentBytes: ArraySlice(sig.derRepresentation))
+        case .rsa(let sig):
+            self = ASN1OctetString(contentBytes: ArraySlice(sig.rawRepresentation))
+        }
+    }
+}

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -550,7 +550,7 @@ final class CMSTests: XCTestCase {
         let signature = try CMS.sign(
             data,
             signatureAlgorithm: .ecdsaWithSHA256,
-            additionalCertificates: [Self.intermediateCert],
+            additionalIntermediateCertificates: [Self.intermediateCert],
             certificate: Self.leaf2Cert,
             privateKey: Self.leaf2Key
         )
@@ -569,7 +569,7 @@ final class CMSTests: XCTestCase {
         let signature = try CMS.sign(
             data,
             signatureAlgorithm: .ecdsaWithSHA256,
-            additionalCertificates: [Self.intermediateCert],
+            additionalIntermediateCertificates: [Self.intermediateCert],
             certificate: Self.leaf2Cert,
             privateKey: Self.leaf2Key
         )
@@ -595,21 +595,21 @@ extension DERSerializable {
 }
 
 fileprivate func XCTAssertValidSignature(_ result: CMS.SignatureVerificationResult, file: StaticString = #file, line: UInt = #line) {
-    guard case .validSignature = result else {
+    guard case .success = result else {
         XCTFail("Expected valid signature, got \(result)", file: file, line: line)
         return
     }
 }
 
 fileprivate func XCTAssertInvalidCMSBlock(_ result: CMS.SignatureVerificationResult, file: StaticString = #file, line: UInt = #line) {
-    guard case .invalidCMSBlock = result else {
+    guard case .failure(.invalidCMSBlock) = result else {
         XCTFail("Expected invalid CMS Block, got \(result)", file: file, line: line)
         return
     }
 }
 
 fileprivate func XCTAssertUnableToValidateSigner(_ result: CMS.SignatureVerificationResult, file: StaticString = #file, line: UInt = #line) {
-    guard case .unableToValidateSigner = result else {
+    guard case .failure(.unableToValidateSigner) = result else {
         XCTFail("Expected unable to validate signer, got \(result)", file: file, line: line)
         return
     }
@@ -619,7 +619,7 @@ extension CMS {
     static func generateSignedTestData<Bytes: DataProtocol>(
         _ bytes: Bytes,
         signatureAlgorithm: Certificate.SignatureAlgorithm,
-        additionalCertificates: [Certificate] = [],
+        additionalIntermediateCertificates: [Certificate] = [],
         certificate: Certificate,
         privateKey: Certificate.PrivateKey
     ) throws -> CMSContentInfo {
@@ -627,7 +627,7 @@ extension CMS {
         return try generateSignedData(
             signatureBytes: ASN1OctetString(signature),
             signatureAlgorithm: signatureAlgorithm,
-            additionalCertificates: additionalCertificates,
+            additionalIntermediateCertificates: additionalIntermediateCertificates,
             certificate: certificate
         )
     }


### PR DESCRIPTION
This patch adds support for basic CMS operations. We aren't sure that the API surface here is right, so for now we're going to provide this under an SPI guard so that we can make any amendments we might need.