### PR TITLE
Fix CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ if(BUILD_SHARED_LIBS)
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  find_package(dispatch CONFIG)
   find_package(Foundation CONFIG)
 endif()
                         

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(X509
   "X509BaseTypes/Validity.swift")
 
 target_link_libraries(X509 PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   Crypto
   _CryptoExtras


### PR DESCRIPTION
When building against a build tree artifact for Foundation, we need to add the build tree artifacts of dispatch as that is an exposed dependency for Foundation.