### PR TITLE
Add initial RFC5280 policy.

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -73,6 +73,8 @@ add_library(X509
   "Signature.swift"
   "SignatureAlgorithm.swift"
   "Verifier/CertificateStore.swift"
+  "Verifier/RFC5280/ExpiryPolicy.swift"
+  "Verifier/RFC5280/RFC5280Policy.swift"
   "Verifier/UnverifiedChain.swift"
   "Verifier/Verifier.swift"
   "Verifier/VerifierPolicy.swift"

--- a/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
@@ -1,0 +1,46 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+/// A sub-policy of the ``RFC5280Policy`` that polices expiry.
+@usableFromInline
+struct ExpiryPolicy: VerifierPolicy {
+    @usableFromInline
+    let validationTime: Date
+
+    @inlinable
+    init(validationTime: Date) {
+        self.validationTime = validationTime
+    }
+
+    @inlinable
+    func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        // This is an easy check: confirm all the certs are valid.
+        for cert in chain {
+            if cert.notValidBefore > cert.notValidAfter {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) has invalid expiry, notValidAfter is earlier than notValidBefore")
+            }
+
+            if self.validationTime < cert.notValidBefore {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) is not yet valid")
+            }
+
+            if self.validationTime > cert.notValidAfter {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) has expired")
+            }
+        }
+
+        return .meetsPolicy
+    }
+}

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -1,0 +1,59 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+/// A ``VerifierPolicy`` that implements the core chain verifying policies from RFC 5280.
+///
+/// Almost all verifiers should use this policy as the initial component of their ``PolicySet``. The policy checks the
+/// following things:
+///
+/// 1. Expiry. Expired certificates are rejected.
+public struct RFC5280Policy: VerifierPolicy {
+    @usableFromInline
+    let validationTime: Date
+
+    @inlinable
+    public init(validationTime: Date) {
+        self.validationTime = validationTime
+    }
+
+    @inlinable
+    public func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        if case .failsToMeetPolicy(let reason) = self._validateExpiry(chain) {
+            return .failsToMeetPolicy(reason: reason)
+        }
+
+        return .meetsPolicy
+    }
+
+    @inlinable
+    func _validateExpiry(_ chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        // This is an easy check: confirm all the certs are valid.
+        for cert in chain {
+            if cert.notValidBefore > cert.notValidAfter {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) has invalid expiry, notValidAfter is earlier than notValidBefore")
+            }
+
+            if self.validationTime < cert.notValidBefore {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) is not yet valid")
+            }
+
+            if self.validationTime > cert.notValidAfter {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) has expired")
+            }
+        }
+
+        return .meetsPolicy
+    }
+}

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -1,0 +1,295 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import XCTest
+import SwiftASN1
+import X509
+import Crypto
+
+final class RFC5280PolicyTests: XCTestCase {
+    func testValidCertsAreAccepted() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(issuer: .unconstrainedIntermediate)
+
+        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: Date())]))
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
+    }
+
+    func testExpiredLeafIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.startDate + 1.0,
+            notValidAfter: TestPKI.startDate + 2.0,  // One second validity window
+            issuer: .unconstrainedIntermediate
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.startDate + 3.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testExpiredIntermediateIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.startDate,
+            notValidAfter: TestPKI.unconstrainedIntermediate.notValidAfter + 2.0,  // Later than the intermediate.
+            issuer: .unconstrainedIntermediate
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots,
+            policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.unconstrainedIntermediate.notValidAfter + 1.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testExpiredRootIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.startDate,
+            notValidAfter: TestPKI.unconstrainedCA.notValidAfter + 2.0,  // Later than the root.
+            issuer: .unconstrainedRoot  // Issue off the root directly to avoid the intermediate getting involved.
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots,
+            policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.unconstrainedCA.notValidAfter + 1.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testNotYetValidLeafIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.startDate + 2.0,
+            notValidAfter: TestPKI.startDate + 3.0,  // One second validity window
+            issuer: .unconstrainedIntermediate
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.startDate + 1.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testNotYetValidIntermediateIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.unconstrainedIntermediate.notValidBefore - 2.0,  // Earlier than the intermediate
+            notValidAfter: TestPKI.unconstrainedIntermediate.notValidAfter,
+            issuer: .unconstrainedIntermediate
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots,
+            policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.unconstrainedIntermediate.notValidBefore - 1.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testNotYetValidRootIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.unconstrainedCA.notValidBefore - 2.0,  // Earlier than the root
+            notValidAfter: TestPKI.startDate,
+            issuer: .unconstrainedRoot  // Issue off the root directly to avoid the intermediate getting involved.
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots,
+            policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.unconstrainedCA.notValidBefore - 1.0)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+
+    func testMalformedExpiryIsRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(
+            notValidBefore: TestPKI.startDate + 3.0,
+            notValidAfter: TestPKI.startDate + 2.0,  // invalid order
+            issuer: .unconstrainedIntermediate
+        )
+
+        var verifier = Verifier(
+            rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: TestPKI.startDate + 2.5)])
+        )
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(policyFailures.count, 1)
+    }
+}
+
+fileprivate enum TestPKI {
+    static let startDate = Date()
+
+    static let unconstrainedCAPrivateKey = P384.Signing.PrivateKey()
+    static let unconstrainedCAName = try! DistinguishedName {
+        CountryName("US")
+        OrganizationName("Apple")
+        CommonName("Swift Certificate Test CA 1")
+    }
+    static let unconstrainedCA: Certificate = {
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(unconstrainedCAPrivateKey.publicKey),
+            notValidBefore: startDate - .days(3650),
+            notValidAfter: startDate + .days(3650),
+            issuer: unconstrainedCAName,
+            subject: unconstrainedCAName,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+                )
+            },
+            issuerPrivateKey: .init(unconstrainedCAPrivateKey)
+        )
+    }()
+
+    static let unconstrainedIntermediateKey = P256.Signing.PrivateKey()
+    static let unconstrainedIntermediateName = try! DistinguishedName {
+        CountryName("US")
+        OrganizationName("Apple")
+        CommonName("Swift Certificate Test Intermediate 1")
+    }
+    static let unconstrainedIntermediate: Certificate = {
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(unconstrainedIntermediateKey.publicKey),
+            notValidBefore: startDate - .days(365),
+            notValidAfter: startDate + .days(365),
+            issuer: unconstrainedCAName,
+            subject: unconstrainedIntermediateName,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+            },
+            issuerPrivateKey: .init(unconstrainedCAPrivateKey)
+        )
+    }()
+
+    enum Issuer {
+        case unconstrainedRoot
+        case unconstrainedIntermediate
+
+        var name: DistinguishedName {
+            switch self {
+            case .unconstrainedRoot:
+                return unconstrainedCAName
+            case .unconstrainedIntermediate:
+                return unconstrainedIntermediateName
+            }
+        }
+
+        var key: Certificate.PrivateKey {
+            switch self {
+            case .unconstrainedRoot:
+                return .init(unconstrainedCAPrivateKey)
+            case .unconstrainedIntermediate:
+                return .init(unconstrainedIntermediateKey)
+            }
+        }
+    }
+
+    static func issueLeaf(
+        commonName: String = "Leaf",
+        notValidBefore: Date = Self.startDate,
+        notValidAfter: Date = Self.startDate + .days(365),
+        issuer: Issuer
+    ) -> Certificate {
+        let leafKey = P256.Signing.PrivateKey()
+        let name = try! DistinguishedName {
+            CountryName("US")
+            OrganizationName("Apple")
+            CommonName(commonName)
+        }
+
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(leafKey.publicKey),
+            notValidBefore: notValidBefore,
+            notValidAfter: notValidAfter,
+            issuer: issuer.name,
+            subject: name,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.notCertificateAuthority
+                )
+            },
+            issuerPrivateKey: issuer.key
+        )
+    }
+}


### PR DESCRIPTION
This is the first of a series of PRs that adds support for RFC 5280 policies as a single verifier policy. For now we take the low hanging fruit, expiry.