### PR TITLE
Avoid re-serializing certificates

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.2.1"),
-        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.6.0")),
+        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.7.0")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ]
 } else {

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -15,8 +15,9 @@
 import Foundation
 import XCTest
 import SwiftASN1
-import X509
+@testable import X509
 import Crypto
+import _CryptoExtras
 
 final class CertificateDERTests: XCTestCase {
     static let base64EncodedSampleCert = """
@@ -301,5 +302,58 @@ final class CertificateDERTests: XCTestCase {
         // Confirm basic signature validation.
         XCTAssertTrue(certs[1].publicKey.isValidSignature(certs[0].signature, for: certs[0]))
         XCTAssertTrue(certs[2].publicKey.isValidSignature(certs[1].signature, for: certs[1]))
+    }
+
+    func testReencodingDoesntChangeTheBytes() throws {
+        // This test validates that we don't change the TBS bytes when we re-encode a certificate.
+        //
+        // The easiest way to do this is to produce a slightly _weird_ certificate that encodes the signature algorithm
+        // in a way we wouldn't.
+        let name = try DistinguishedName {
+            CommonName("Test")
+        }
+        let key = try _RSA.Signing.PrivateKey(keySize: .bits2048)
+
+        var coder = DER.Serializer()
+        try coder.appendConstructedNode(identifier: .sequence) { coder in
+            try coder.serialize(Certificate.Version.v3.rawValue, explicitlyTaggedWithTagNumber: 0, tagClass: .contextSpecific)
+            try coder.serialize(Certificate.SerialNumber().bytes)
+            try coder.serialize(AlgorithmIdentifier.sha256WithRSAEncryptionUsingNil)
+            try coder.serialize(name)
+            try coder.serialize(try Validity(notBefore: .makeTime(from: Date()), notAfter: .makeTime(from: Date() + 100)))
+            try coder.serialize(name)
+            try coder.serialize(SubjectPublicKeyInfo(.init(key.publicKey)))
+        }
+
+        let tbsCertificateBytes = coder.serializedBytes
+
+        // Ok, we can construct this into a real certificate now by signing it and producing the signature block.
+        let signature = try Certificate.PrivateKey(key).sign(bytes: tbsCertificateBytes, signatureAlgorithm: .sha256WithRSAEncryption)
+
+        coder = DER.Serializer()
+        try coder.appendConstructedNode(identifier: .sequence) { coder in
+            coder.serializeRawBytes(tbsCertificateBytes)
+            try coder.serialize(AlgorithmIdentifier.sha256WithRSAEncryptionUsingNil)
+            try coder.serialize(ASN1BitString(signature))
+        }
+
+        let serializedCert = coder.serializedBytes
+
+        // Great, done! Now we can deserialize this into a certificate, which should happen without error.
+        // Do a few spot checks to confirm it came out ok.
+        let cert = try Certificate(derEncoded: serializedCert)
+        XCTAssertEqual(cert.subject, name)
+        XCTAssertEqual(cert.issuer, name)
+        XCTAssertEqual(cert.version, .v3)
+        XCTAssertEqual(cert.signatureAlgorithm, .sha256WithRSAEncryption)
+        XCTAssertEqual(cert.publicKey, Certificate.PublicKey(key.publicKey))
+        XCTAssertTrue(Certificate.PublicKey(key.publicKey).isValidSignature(cert.signature, for: cert))
+
+        // Ok, serialize it back. We must not have canonicalised this.
+        coder = DER.Serializer()
+        try coder.serialize(cert)
+        let reserializedCert = coder.serializedBytes
+
+        XCTAssertEqual(reserializedCert, serializedCert)
     }
 }


### PR DESCRIPTION
When we decode a certificate, we produce an in-memory representation. This representation is something we are capable of encoding. If we re-encode that directly, we can produce an output that is different to the one we injested. This happens when there are objects that can be canonicalised, such as replacing an explicit ASN1 NULL with an absent field where both are considered equivalent.

This patch rewrites the code to ensure that we preserve the bytes of the certificate that we deserialized. This allows us to write them back unchanged, ensuring that certificates can round-trip through this library without modification.

A side-effect of this change is that we need to essentially encode the certificate on construction whenever we build them in memory. That's not a big deal, but it is a bit of an annoyance.