### PR TITLE
Add BasicConstraints enforcement to RF5280Policy

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -73,6 +73,7 @@ add_library(X509
   "Signature.swift"
   "SignatureAlgorithm.swift"
   "Verifier/CertificateStore.swift"
+  "Verifier/RFC5280/BasicConstraintsPolicy.swift"
   "Verifier/RFC5280/ExpiryPolicy.swift"
   "Verifier/RFC5280/RFC5280Policy.swift"
   "Verifier/UnverifiedChain.swift"

--- a/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+/// A sub-policy of the ``RFC5280Policy`` that polices the basicConstraints extension.
+@usableFromInline
+struct BasicConstraintsPolicy: VerifierPolicy {
+    @inlinable
+    init() { }
+
+    @inlinable
+    func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        // The rules for BasicConstraints come from https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9,
+        // but roughly can be summarised as:
+        //
+        // 1. If basicConstraints is absent, the cert must not be used as an issuing certificate.
+        // 2. If basicConstraints is present and does not assert that this is a CA, this must not be used
+        //        as an issuing certificate.
+        // 3. If basic constraints is present, and the CA bit is present, and there is a path length constraint,
+        //        then this certificate may not have more sub CAs than the path length constraint allows.
+        //
+        // RFC 5280 also wants us to enforce key usage. Unfortunately, as a practical matter, browsers don't. That
+        // means that other implementations, like Go and webpki, also don't. To maximise compatibility, we don't either.
+        var chain = chain[...]
+        guard let leaf = chain.popFirst() else {
+            // This is conceptually impossible, but we'll tolerate it.
+            return .failsToMeetPolicy(reason: "RFC5280Policy: Empty certificate chain")
+        }
+
+        // We check for the special-case of a trust root being presented as the end entity cert. If that's what's
+        // happening, we require that this cert be marked as a CA.
+        if chain.count == 0 {
+            do {
+                switch try leaf.extensions.basicConstraints {
+                case .some(.isCertificateAuthority):
+                    return .meetsPolicy
+                case .some(.notCertificateAuthority), .none:
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: Self-signed cert \(leaf) is not marked as a CA")
+                }
+            } catch {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Error processing basic constraints for \(leaf): \(error)")
+            }
+        }
+
+        // Now we check the chain.
+        var subCACount = 0
+
+        for cert in chain {
+            do {
+                switch try cert.extensions.basicConstraints {
+                case .some(.isCertificateAuthority(.some(let maxPathLength))) where maxPathLength < subCACount:
+                    // Is a CA, but the max path length is smaller than the number of sub CAs we have.
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: CA \(cert) has maximum path length \(maxPathLength), but chain has \(subCACount) subCAs")
+
+                case .some(.isCertificateAuthority):
+                    // Is a CA, but either the max path length is at least as large as our current set of sub CAs, or there isn't one.
+                    // Continue to the next cert.
+                    ()
+
+                case .some(.notCertificateAuthority), .none:
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) is not marked as a CA")
+                }
+            } catch {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Error processing basic constraints for \(cert): \(error)")
+            }
+
+            subCACount += 1
+        }
+
+        return .meetsPolicy
+    }
+}

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -23,14 +23,22 @@ public struct RFC5280Policy: VerifierPolicy {
     @usableFromInline
     let expiryPolicy: ExpiryPolicy
 
+    @usableFromInline
+    let basicConstraintsPolicy: BasicConstraintsPolicy
+
     @inlinable
     public init(validationTime: Date) {
         self.expiryPolicy = ExpiryPolicy(validationTime: validationTime)
+        self.basicConstraintsPolicy = BasicConstraintsPolicy()
     }
 
     @inlinable
     public func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
         if case .failsToMeetPolicy(let reason) = self.expiryPolicy.chainMeetsPolicyRequirements(chain: chain) {
+            return .failsToMeetPolicy(reason: reason)
+        }
+
+        if case .failsToMeetPolicy(let reason) = self.basicConstraintsPolicy.chainMeetsPolicyRequirements(chain: chain) {
             return .failsToMeetPolicy(reason: reason)
         }
 

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -22,6 +22,7 @@ final class RFC5280PolicyTests: XCTestCase {
     enum PolicyFactory {
         case rfc5280
         case expiry
+        case basicConstraints
 
         func create(_ validationTime: Date) -> VerifierPolicy {
             switch self {
@@ -29,6 +30,8 @@ final class RFC5280PolicyTests: XCTestCase {
                 return RFC5280Policy(validationTime: validationTime)
             case .expiry:
                 return ExpiryPolicy(validationTime: validationTime)
+            case .basicConstraints:
+                return BasicConstraintsPolicy()
             }
         }
     }
@@ -254,6 +257,279 @@ final class RFC5280PolicyTests: XCTestCase {
     func testMalformedExpiryIsRejectedBasePolicy() async throws {
         try await self._malformedExpiryIsRejected(.expiry)
     }
+
+    // This is a BasicConstraints extension that is invalid gibberish
+    private static let brokenBasicConstraints = Certificate.Extension(
+        oid: .X509ExtensionID.basicConstraints, critical: true, value: [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    )
+
+    func _selfSignedCertsMustBeMarkedAsCA(_ policyFactory: PolicyFactory) async throws {
+        let certsAndValidity = [
+            (TestPKI.issueSelfSignedCert(basicConstraints: .isCertificateAuthority(maxPathLength: nil)), true),
+            (TestPKI.issueSelfSignedCert(basicConstraints: .isCertificateAuthority(maxPathLength: 0)), true),
+            (TestPKI.issueSelfSignedCert(basicConstraints: .notCertificateAuthority), false),
+            (TestPKI.issueSelfSignedCert(customExtensions: Certificate.Extensions([Self.brokenBasicConstraints])), false)
+        ]
+
+        for (cert, isValid) in certsAndValidity {
+            var verifier = Verifier(
+                rootCertificates: CertificateStore([cert]),
+                policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+            )
+            let result = await verifier.validate(leafCertificate: cert, intermediates: CertificateStore([]))
+
+            switch (result, isValid) {
+            case (.validCertificate, true),
+                (.couldNotValidate, false):
+                ()
+            case (_, true):
+                XCTFail("Failed to validate: \(result) \(cert)")
+            case (_, false):
+                XCTFail("Incorrectly validated: \(result) \(cert)")
+            }
+        }
+    }
+
+    func testSelfSignedCertsMustBeMarkedAsCA() async throws {
+        try await self._selfSignedCertsMustBeMarkedAsCA(.rfc5280)
+    }
+
+    func testSelfSignedCertsMustBeMarkedAsCABasePolicy() async throws {
+        try await self._selfSignedCertsMustBeMarkedAsCA(.basicConstraints)
+    }
+
+    func _intermediateCAMustBeMarkedCAInBasicConstraints(_ policyFactory: PolicyFactory) async throws {
+        let invalidIntermediateCAs = [
+            // Explicitly not being a CA is bad
+            TestPKI.issueIntermediate(
+                name: TestPKI.unconstrainedIntermediateName,
+                key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+                extensions: try! Certificate.Extensions {
+                    Critical(
+                        BasicConstraints.notCertificateAuthority
+                    )
+                },
+                issuer: .unconstrainedRoot
+            ),
+
+            // Not having BasicConstraints at all is also bad.
+            TestPKI.issueIntermediate(
+                name: TestPKI.unconstrainedIntermediateName,
+                key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+                extensions: Certificate.Extensions([]),
+                issuer: .unconstrainedRoot
+            ),
+
+            // As is having broken BasicConstraints
+            TestPKI.issueIntermediate(
+                name: TestPKI.unconstrainedIntermediateName,
+                key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+                extensions: Certificate.Extensions([Self.brokenBasicConstraints]),
+                issuer: .unconstrainedRoot
+            )
+        ]
+
+        let leaf = TestPKI.issueLeaf(issuer: .unconstrainedIntermediate)
+
+        for badIntermediate in invalidIntermediateCAs {
+            var verifier = Verifier(
+                rootCertificates: CertificateStore([TestPKI.unconstrainedCA]),
+                policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+            )
+            var result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([badIntermediate]))
+
+            guard case .couldNotValidate = result else {
+                XCTFail("Incorrectly validated with \(badIntermediate) in chain")
+                return
+            }
+
+            // Adding the better CA in works better, _and_ we don't use the bad intermediate!
+            verifier = Verifier(
+                rootCertificates: CertificateStore([TestPKI.unconstrainedCA]),
+                policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+            )
+            result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([badIntermediate, TestPKI.unconstrainedIntermediate]))
+
+            guard case .validCertificate(let chain) = result else {
+                XCTFail("Unable to validate with both bad and good intermediate in chain")
+                return
+            }
+
+            XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
+        }
+    }
+
+    func testIntermediateCAMustBeMarkedAsCAInBasicConstraints() async throws {
+        try await self._intermediateCAMustBeMarkedCAInBasicConstraints(.rfc5280)
+    }
+
+    func testIntermediateCAMustBeMarkedAsCAInBasicConstraintsBasePolicy() async throws {
+        try await self._intermediateCAMustBeMarkedCAInBasicConstraints(.basicConstraints)
+    }
+
+    func _rootCAMustBeMarkedCAInBasicConstraints(_ policyFactory: PolicyFactory) async throws {
+        let invalidRootCAs = [
+            // Explicitly not being a CA is bad
+            TestPKI.issueCA(extensions: try! Certificate.Extensions {
+                Critical(
+                    BasicConstraints.notCertificateAuthority
+                )
+            }),
+
+            // Not having BasicConstraints at all is also bad.
+            TestPKI.issueCA(extensions: Certificate.Extensions([])),
+
+            // As is having broken BasicConstraints
+            TestPKI.issueCA(extensions: Certificate.Extensions([Self.brokenBasicConstraints]))
+        ]
+
+        let leaf = TestPKI.issueLeaf(issuer: .unconstrainedIntermediate)
+
+        for badRoot in invalidRootCAs {
+            var verifier = Verifier(
+                rootCertificates: CertificateStore([badRoot]),
+                policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+            )
+            var result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+            guard case .couldNotValidate = result else {
+                XCTFail("Incorrectly validated with \(badRoot) in chain")
+                return
+            }
+
+            // Adding the better CA in works better, _and_ we don't use the bad root!
+            verifier = Verifier(
+                rootCertificates: CertificateStore([badRoot, TestPKI.unconstrainedCA]),
+                policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+            )
+            result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+            guard case .validCertificate(let chain) = result else {
+                XCTFail("Unable to validate with both bad and good root in chain")
+                return
+            }
+
+            XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
+        }
+    }
+
+    func testRootCAMustBeMarkedAsCAInBasicConstraints() async throws {
+        try await self._rootCAMustBeMarkedCAInBasicConstraints(.rfc5280)
+    }
+
+    func testRootCAMustBeMarkedAsCAInBasicConstraintsBasePolicy() async throws {
+        try await self._rootCAMustBeMarkedCAInBasicConstraints(.basicConstraints)
+    }
+
+    func _pathLengthConstraintsFromIntermediatesAreApplied(_ policyFactory: PolicyFactory) async throws {
+        // This test requires that we use a second-level intermediate, to police the first-level
+        // intermediate's path length constraint. This second level intermediate has a valid path length
+        // constraint.
+        let secondLevelIntermediate = TestPKI.issueIntermediate(
+            name: TestPKI.secondLevelIntermediateName,
+            key: .init(TestPKI.secondLevelIntermediateKey.publicKey),
+            extensions: try! Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+            },
+            issuer: .unconstrainedIntermediate
+        )
+
+        let leaf = TestPKI.issueLeaf(issuer: .secondLevelIntermediate)
+
+        var verifier = Verifier(
+            rootCertificates: CertificateStore([TestPKI.unconstrainedCA]),
+            policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+        )
+        var result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([secondLevelIntermediate, TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate = result else {
+            XCTFail("Incorrectly validated with \(secondLevelIntermediate) in chain")
+            return
+        }
+
+        // Creating a new first-level intermediate with a better path length constraint works!
+        let newFirstLevelIntermediate = TestPKI.issueIntermediate(
+            name: TestPKI.unconstrainedIntermediateName,
+            key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+            extensions: try! Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 1)
+                )
+            },
+            issuer: .unconstrainedRoot
+        )
+
+        verifier = Verifier(
+            rootCertificates: CertificateStore([TestPKI.unconstrainedCA]),
+            policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+        )
+        result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([secondLevelIntermediate, newFirstLevelIntermediate, TestPKI.unconstrainedIntermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Unable to validate with both bad and good intermediate in chain")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, secondLevelIntermediate, newFirstLevelIntermediate, TestPKI.unconstrainedCA])
+    }
+
+    func testPathLengthConstraintsFromIntermediatesAreApplied() async throws {
+        try await self._pathLengthConstraintsFromIntermediatesAreApplied(.rfc5280)
+    }
+
+    func testPathLengthConstraintsFromIntermediatesAreAppliedBasePolicy() async throws {
+        try await self._pathLengthConstraintsFromIntermediatesAreApplied(.basicConstraints)
+    }
+
+    func _pathLengthConstraintsOnRootsAreApplied(_ policyFactory: PolicyFactory) async throws {
+        // This test requires that we use a second-level intermediate, to police the first-level
+        // intermediate's path length constraint. This second level intermediate has a valid path length
+        // constraint.
+        let alternativeRoot = TestPKI.issueCA(
+            extensions: try! Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+            }
+        )
+
+        let leaf = TestPKI.issueLeaf(issuer: .unconstrainedIntermediate)
+
+        var verifier = Verifier(
+            rootCertificates: CertificateStore([alternativeRoot]),
+            policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+        )
+        var result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate = result else {
+            XCTFail("Incorrectly validated with \(alternativeRoot) in chain")
+            return
+        }
+
+        // Adding back the good root works!
+        verifier = Verifier(
+            rootCertificates: CertificateStore([alternativeRoot, TestPKI.unconstrainedCA]),
+            policy: PolicySet(policies: [policyFactory.create(TestPKI.startDate + 2.5)])
+        )
+        result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Unable to validate with both bad and good intermediate in chain")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
+    }
+
+    func testPathLengthConstraintsOnRootsAreApplied() async throws {
+        try await self._pathLengthConstraintsFromIntermediatesAreApplied(.rfc5280)
+    }
+
+    func testPathLengthConstraintsOnRootsAreAppliedBasePolicy() async throws {
+        try await self._pathLengthConstraintsFromIntermediatesAreApplied(.basicConstraints)
+    }
 }
 
 fileprivate enum TestPKI {
@@ -283,6 +559,20 @@ fileprivate enum TestPKI {
             issuerPrivateKey: .init(unconstrainedCAPrivateKey)
         )
     }()
+    static func issueCA(extensions: Certificate.Extensions) -> Certificate {
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(unconstrainedCAPrivateKey.publicKey),
+            notValidBefore: startDate - .days(3650),
+            notValidAfter: startDate + .days(3650),
+            issuer: unconstrainedCAName,
+            subject: unconstrainedCAName,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: extensions,
+            issuerPrivateKey: .init(unconstrainedCAPrivateKey)
+        )
+    }
 
     static let unconstrainedIntermediateKey = P256.Signing.PrivateKey()
     static let unconstrainedIntermediateName = try! DistinguishedName {
@@ -291,27 +581,43 @@ fileprivate enum TestPKI {
         CommonName("Swift Certificate Test Intermediate 1")
     }
     static let unconstrainedIntermediate: Certificate = {
-        return try! Certificate(
-            version: .v3,
-            serialNumber: .init(),
-            publicKey: .init(unconstrainedIntermediateKey.publicKey),
-            notValidBefore: startDate - .days(365),
-            notValidAfter: startDate + .days(365),
-            issuer: unconstrainedCAName,
-            subject: unconstrainedIntermediateName,
-            signatureAlgorithm: .ecdsaWithSHA256,
-            extensions: Certificate.Extensions {
+        return issueIntermediate(
+            name: unconstrainedIntermediateName,
+            key: .init(unconstrainedIntermediateKey.publicKey),
+            extensions: try! Certificate.Extensions {
                 Critical(
                     BasicConstraints.isCertificateAuthority(maxPathLength: 0)
                 )
             },
-            issuerPrivateKey: .init(unconstrainedCAPrivateKey)
+            issuer: .unconstrainedRoot
         )
     }()
+    static func issueIntermediate(name: DistinguishedName, key: Certificate.PublicKey, extensions: Certificate.Extensions, issuer: Issuer) -> Certificate {
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: key,
+            notValidBefore: startDate - .days(365),
+            notValidAfter: startDate + .days(365),
+            issuer: issuer.name,
+            subject: name,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: extensions,
+            issuerPrivateKey: issuer.key
+        )
+    }
+
+    static let secondLevelIntermediateKey = P256.Signing.PrivateKey()
+    static let secondLevelIntermediateName = try! DistinguishedName {
+        CountryName("US")
+        OrganizationName("Apple")
+        CommonName("Swift Certificate Test Intermediate 2")
+    }
 
     enum Issuer {
         case unconstrainedRoot
         case unconstrainedIntermediate
+        case secondLevelIntermediate
 
         var name: DistinguishedName {
             switch self {
@@ -319,6 +625,8 @@ fileprivate enum TestPKI {
                 return unconstrainedCAName
             case .unconstrainedIntermediate:
                 return unconstrainedIntermediateName
+            case .secondLevelIntermediate:
+                return secondLevelIntermediateName
             }
         }
 
@@ -328,6 +636,8 @@ fileprivate enum TestPKI {
                 return .init(unconstrainedCAPrivateKey)
             case .unconstrainedIntermediate:
                 return .init(unconstrainedIntermediateKey)
+            case .secondLevelIntermediate:
+                return .init(secondLevelIntermediateKey)
             }
         }
     }
@@ -360,6 +670,44 @@ fileprivate enum TestPKI {
                 )
             },
             issuerPrivateKey: issuer.key
+        )
+    }
+
+    static func issueSelfSignedCert(
+        commonName: String = "Leaf",
+        basicConstraints: BasicConstraints = .notCertificateAuthority,
+        customExtensions: Certificate.Extensions? = nil
+    ) -> Certificate {
+        let selfSignedKey = P256.Signing.PrivateKey()
+        let name = try! DistinguishedName {
+            CountryName("US")
+            OrganizationName("Apple")
+            CommonName(commonName)
+        }
+
+        let extensions: Certificate.Extensions
+
+        if let customExtensions {
+            extensions = customExtensions
+        } else {
+            extensions = try! Certificate.Extensions {
+                Critical(
+                    basicConstraints
+                )
+            }
+        }
+
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(selfSignedKey.publicKey),
+            notValidBefore: Self.startDate,
+            notValidAfter: Self.startDate + .days(365),
+            issuer: name,
+            subject: name,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: extensions,
+            issuerPrivateKey: Certificate.PrivateKey(selfSignedKey)
         )
     }
 }


### PR DESCRIPTION
This patch adds support for enforcing BasicConstraints in the RFC 5280 policy.