### PR TITLE
Update Swift Crypto and fix RSA keys

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.2.1"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.4.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.7.0")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ]

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -82,6 +82,7 @@ add_library(X509
   "Verifier/Verifier.swift"
   "Verifier/VerifierPolicy.swift"
   "X509BaseTypes/AlgorithmIdentifier.swift"
+  "X509BaseTypes/RSAPKCS1PublicKey.swift"
   "X509BaseTypes/SubjectPublicKeyInfo.swift"
   "X509BaseTypes/TBSCertificate.swift"
   "X509BaseTypes/Time.swift"

--- a/Sources/X509/X509BaseTypes/RSAPKCS1PublicKey.swift
+++ b/Sources/X509/X509BaseTypes/RSAPKCS1PublicKey.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftASN1
+
+/// An RSA PKCS1 Public Key looks like this:
+///
+/// ```
+/// RSAPublicKey ::= SEQUENCE {
+///     modulus           INTEGER,  -- n
+///     publicExponent    INTEGER   -- e
+/// }
+/// ```
+///
+/// This type can decode that format.
+@usableFromInline
+struct RSAPKCS1PublicKey: DERImplicitlyTaggable, Hashable, Sendable {
+    @inlinable
+    static var defaultIdentifier: ASN1Identifier {
+        .sequence
+    }
+
+    @usableFromInline
+    var modulus: ArraySlice<UInt8>
+
+    @usableFromInline
+    var publicExponent: ArraySlice<UInt8>
+
+    @inlinable
+    init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
+        self = try DER.sequence(rootNode, identifier: identifier) { nodes in
+            let modulus = try ArraySlice(derEncoded: &nodes)
+            let publicExponent = try ArraySlice(derEncoded: &nodes)
+
+            return RSAPKCS1PublicKey(modulus: modulus, publicExponent: publicExponent)
+        }
+    }
+
+    @inlinable
+    init(modulus: ArraySlice<UInt8>, publicExponent: ArraySlice<UInt8>) {
+        self.modulus = modulus
+        self.publicExponent = publicExponent
+    }
+
+
+    @inlinable
+    func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
+        try coder.appendConstructedNode(identifier: identifier) { coder in
+            try coder.serialize(self.modulus)
+            try coder.serialize(self.publicExponent)
+        }
+    }
+}
+

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -356,4 +356,17 @@ final class CertificateDERTests: XCTestCase {
 
         XCTAssertEqual(reserializedCert, serializedCert)
     }
+
+    func testRSAKeyFormatOutputIsCorrect() throws {
+        // A quick test here, we just encode and decode an RSA key.
+        let publicKey = try Certificate.PublicKey(_RSA.Signing.PrivateKey(keySize: .bits2048).publicKey)
+        let spki = SubjectPublicKeyInfo(publicKey)
+
+        var encoder = DER.Serializer()
+        try encoder.serialize(spki)
+
+        let decodedSPKI = try SubjectPublicKeyInfo(derEncoded: encoder.serializedBytes)
+        let newKey = try Certificate.PublicKey(spki: decodedSPKI)
+        XCTAssertEqual(publicKey, newKey)
+    }
 }


### PR DESCRIPTION
This updates Swift Crypto to 2.4.0 and fixes RSA key serialization on all platforms. It also adds a defensive check that we only accept appropriately-formatted RSA keys, and some regression tests.