### PR TITLE
Fix `Certificate.SerialNumber.init()`

### DIFF
--- a/Sources/X509/CertificateSerialNumber.swift
+++ b/Sources/X509/CertificateSerialNumber.swift
@@ -64,7 +64,13 @@ extension Certificate {
         @inlinable
         public init() {
             var rng = SystemRandomNumberGenerator()
-            self.bytes = rng.bytes(count: 20)
+            self.init(generator: &rng)
+        }
+        
+        @inlinable
+        internal init(generator: inout some RandomNumberGenerator) {
+            // drop leading zeros as required by the ASN.1 spec for INTEGERs
+            self.bytes = generator.bytes(count: 20).drop(while: { $0 == 0 })
         }
     }
 }


### PR DESCRIPTION
`Certificate.SerialNumber.init()` could produce a number where the first byte(s) could be zero(s). We strip them during encoding and will not and cannot reconstruct them after decoding. Therefore a serial number might no longer be equal to itself after a de/serialisation roundtrip. We have observed this behaviour to cause problems in the OCSP test suite with random test failures. This PR fixes it by dropping leading zeros.