### PR TITLE
Add directory name constraints.

### DIFF
--- a/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
+++ b/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension NameConstraintsPolicy {
+    /// Validates that a directory name matches a name constraint.
+    ///
+    /// There's a complex algorithm for doing proper directory name constraints validation.
+    /// However, most implementations don't bother, and just directly compare the distinguished
+    /// names.
+    @inlinable
+    static func directoryNameMatchesConstraint(directoryName: DistinguishedName, constraint: DistinguishedName) -> Bool {
+        return directoryName == constraint
+    }
+}

--- a/Tests/X509Tests/NameConstraintsTests.swift
+++ b/Tests/X509Tests/NameConstraintsTests.swift
@@ -1,0 +1,51 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftASN1
+@testable import X509
+
+final class NameConstraintsTests: XCTestCase {
+    func testDirectoryNameMatches() throws {
+        // The key here is that a distinguished name only matches a constraint if they're equal.
+        let names: [DistinguishedName] = [
+            try DistinguishedName {
+                CountryName("US")
+                StateOrProvinceName("CA")
+                OrganizationName("Apple")
+            },
+            try DistinguishedName {
+                CountryName("US")
+                StateOrProvinceName("CA")
+                OrganizationName("Apple")
+                CommonName("Test")
+            },
+            try DistinguishedName {
+                CountryName("GB")
+                OrganizationName("Apple")
+                CommonName("Test")
+            },
+        ]
+
+        for firstName in names {
+            for secondName in names {
+                XCTAssertEqual(
+                    NameConstraintsPolicy.directoryNameMatchesConstraint(directoryName: firstName, constraint: secondName),
+                    firstName == secondName,
+                    "Expected directory name match to be \(firstName == secondName) for \(firstName) and \(secondName)"
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Just to round things out we can add directory name constraints. There's nominally a fairly complex algorithm for validating directory name constraints, but most implementations don't bother, instead falling back to direct matches.