### PR TITLE
Produce functional NameConstraints

### DIFF
--- a/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
@@ -21,7 +21,224 @@ struct NameConstraintsPolicy: VerifierPolicy {
 
     @inlinable
     func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
-        // For now we don't implement this, we'll add support later.
+        // The rules for name constraints come from https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.10.
+        //
+        // Some notes:
+        //
+        // - RFC 5280 says we MUST validate directoryName constraints, and SHOULD validate rfc822Name,
+        //       URI, dNSName, and iPAddress constraints.
+        // - If there's a constraint we don't support and can't validate, we MUST reject the cert.
+        //
+        // Our algorithm is recursive: starting from the root and moving towards the leaf, for each CA
+        // cert we apply the name constraints to all of the other certificates in the chain. The one exception
+        // is for self-signed certs where, much like with basic constraints, we briefly pretend that the
+        // self-signed cert issued itself and enforce its own name constraints on it.
+        if chain.count == 1 {
+            return Self._validateNameConstraints(chain[...], issuer: chain.first!)
+        }
+
+        var issuedCerts = chain[...]
+        while let issuer = issuedCerts.popLast(), issuedCerts.count > 0 {
+            if case .failsToMeetPolicy(let reason) = Self._validateNameConstraints(issuedCerts, issuer: issuer) {
+                return .failsToMeetPolicy(reason: reason)
+            }
+        }
+
         return .meetsPolicy
+    }
+
+    @inlinable
+    static func _validateNameConstraints(
+        _ issuedCerts: UnverifiedCertificateChain.SubSequence,
+        issuer: Certificate
+    ) -> PolicyEvaluationResult {
+        let maybeConstraints: NameConstraints?
+
+        do {
+            maybeConstraints = try issuer.extensions.nameConstraints
+        } catch {
+            // We couldn't decode these! Fail validation.
+            return .failsToMeetPolicy(reason: "RFC5280Policy: Unable to decode name constraints from \(issuer)")
+        }
+
+        guard let constraints = maybeConstraints else {
+            // No name constraints to enforce, we're done.
+            return .meetsPolicy
+        }
+
+        for cert in issuedCerts {
+            let names: Certificate.NameSequence
+
+            do {
+                names = try cert.names
+            } catch {
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Unable to decode SAN field of \(cert): \(error)")
+            }
+
+            for name in names {
+                if case .failsToMeetPolicy(let reason) = Self._validatePermittedSubtrees(constraints.permittedSubtrees, name) {
+                    return .failsToMeetPolicy(reason: reason)
+                }
+
+                if case .failsToMeetPolicy(let reason) = Self._validateExcludedSubtrees(constraints.excludedSubtrees, name) {
+                    return .failsToMeetPolicy(reason: reason)
+                }
+            }
+        }
+
+        return .meetsPolicy
+    }
+
+    @inlinable
+    static func _validateExcludedSubtrees(
+        _ excludedSubtrees: [GeneralName], _ name: GeneralName
+    ) -> PolicyEvaluationResult {
+        // For excluded trees, if _any_ match then the name is forbidden.
+        for excludedSubtree in excludedSubtrees {
+            switch (excludedSubtree, name) {
+            case (.directoryName(let constraint), .directoryName(let presentedName)):
+                if directoryNameMatchesConstraint(directoryName: presentedName, constraint: constraint) {
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: directoryName \(presentedName) is excluded by \(excludedSubtree) in name constraints")
+                }
+            case (.dNSName(let constraint), .dNSName(let presentedName)):
+                if dnsNameMatchesConstraint(dnsName: presentedName.utf8, constraint: constraint.utf8) {
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: dNSName \(presentedName) is excluded by \(excludedSubtree) in name constraints")
+                }
+            case (.iPAddress(let constraint), .iPAddress(let presentedName)):
+                if ipAddressMatchesConstraint(ipAddress: presentedName, constraint: constraint) {
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: ipAddress \(presentedName) is excluded by \(excludedSubtree) in name constraints")
+                }
+            case (.uniformResourceIdentifier(let constraint), .uniformResourceIdentifier(let presentedName)):
+                if uriNameMatchesConstraint(uriName: presentedName, constraint: constraint) {
+                    return .failsToMeetPolicy(reason: "RFC5280Policy: URI \(presentedName) is excluded by \(excludedSubtree) in name constraints")
+                }
+            case (.directoryName, _), (.dNSName, _), (.iPAddress, _), (.uniformResourceIdentifier, _):
+                // We support these, but the current name isn't of that type.
+                continue
+            default:
+                // We don't support constraints on these!
+                //
+                // Of the set that's currently unsupported, we should probably support rfc822Name (a.k.a. email address).
+                // For now we're omitting it, but at some point someone is going to run into this limitation and we'll want to come
+                // back and fix it.
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Unable to validate excluded subtree for name \(excludedSubtree), unsupported constraint")
+            }
+        }
+
+        // No policy rejected this.
+        return .meetsPolicy
+    }
+
+    @inlinable
+    static func _validatePermittedSubtrees(
+        _ permittedSubtrees: [GeneralName], _ name: GeneralName
+    ) -> PolicyEvaluationResult {
+        var evaluatedAtLeastOneConstraint = false
+
+        for permittedSubtree in permittedSubtrees {
+            switch (permittedSubtree, name) {
+            case (.directoryName(let constraint), .directoryName(let presentedName)):
+                evaluatedAtLeastOneConstraint = true
+
+                if directoryNameMatchesConstraint(directoryName: presentedName, constraint: constraint) {
+                    // This is a match, we're good.
+                    return .meetsPolicy
+                }
+
+            case (.dNSName(let constraint), .dNSName(let presentedName)):
+                evaluatedAtLeastOneConstraint = true
+
+                if dnsNameMatchesConstraint(dnsName: presentedName.utf8, constraint: constraint.utf8) {
+                    // This is a match, we're good.
+                    return .meetsPolicy
+                }
+            case (.iPAddress(let constraint), .iPAddress(let presentedName)):
+                evaluatedAtLeastOneConstraint = true
+
+                if ipAddressMatchesConstraint(ipAddress: presentedName, constraint: constraint) {
+                    // This is a match, we're good.
+                    return .meetsPolicy
+                }
+            case (.uniformResourceIdentifier(let constraint), .uniformResourceIdentifier(let presentedName)):
+                evaluatedAtLeastOneConstraint = true
+
+                if uriNameMatchesConstraint(uriName: presentedName, constraint: constraint) {
+                    // This is a match, we're good.
+                    return .meetsPolicy
+                }
+            case (.directoryName, _), (.dNSName, _), (.iPAddress, _), (.uniformResourceIdentifier, _):
+                // We support these, but the current name isn't of that type. This means we didn't evaluate
+                // this constraint.
+                continue
+            default:
+                // We don't support constraints on these!
+                //
+                // Of the set that's currently unsupported, we should probably support rfc822Name (a.k.a. email address).
+                // For now we're omitting it, but at some point someone is going to run into this limitation and we'll want to come
+                // back and fix it.
+                return .failsToMeetPolicy(reason: "RFC5280Policy: Unable to validate permitted subtree for name \(permittedSubtree), unsupported constraint")
+            }
+        }
+
+        // Uh-oh, nothing matched! This is only a problem if we have at least one constraint for the given type.
+        if evaluatedAtLeastOneConstraint {
+            return .failsToMeetPolicy(reason: "RFC5280Policy: Unable to validate permitted subtree for \(permittedSubtrees), no matches!")
+        } else {
+            return .meetsPolicy
+        }
+    }
+}
+
+extension Certificate {
+    @inlinable
+    var names: NameSequence {
+        get throws {
+            return try NameSequence(self)
+        }
+    }
+
+    @usableFromInline
+    struct NameSequence: Sequence {
+        @usableFromInline
+        var subject: DistinguishedName
+
+        @usableFromInline
+        var alternativeNames: SubjectAlternativeNames
+
+        @inlinable
+        init(_ certificate: Certificate) throws {
+            self.subject = certificate.subject
+            self.alternativeNames = try certificate.extensions.subjectAlternativeNames ?? .init()
+        }
+
+        @inlinable
+        func makeIterator() -> Iterator {
+            return Iterator(self.subject, self.alternativeNames)
+        }
+
+        @usableFromInline
+        struct Iterator: IteratorProtocol {
+            @usableFromInline
+            var subject: DistinguishedName?
+
+            @usableFromInline
+            var alternativeNames: SubjectAlternativeNames.SubSequence
+
+            @inlinable
+            init(_ subject: DistinguishedName, _ alternativeNames: SubjectAlternativeNames) {
+                self.subject = subject
+                self.alternativeNames = alternativeNames[...]
+            }
+
+            @inlinable
+            mutating func next() -> GeneralName? {
+                if let subject = self.subject {
+                    self.subject = nil
+                    return .directoryName(subject)
+                } else {
+                    return self.alternativeNames.popFirst()
+                }
+            }
+        }
     }
 }

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -26,10 +26,14 @@ public struct RFC5280Policy: VerifierPolicy {
     @usableFromInline
     let basicConstraintsPolicy: BasicConstraintsPolicy
 
+    @usableFromInline
+    let nameConstraintsPolicy: NameConstraintsPolicy
+
     @inlinable
     public init(validationTime: Date) {
         self.expiryPolicy = ExpiryPolicy(validationTime: validationTime)
         self.basicConstraintsPolicy = BasicConstraintsPolicy()
+        self.nameConstraintsPolicy = NameConstraintsPolicy()
     }
 
     @inlinable
@@ -39,6 +43,10 @@ public struct RFC5280Policy: VerifierPolicy {
         }
 
         if case .failsToMeetPolicy(let reason) = self.basicConstraintsPolicy.chainMeetsPolicyRequirements(chain: chain) {
+            return .failsToMeetPolicy(reason: reason)
+        }
+
+        if case .failsToMeetPolicy(let reason) = self.nameConstraintsPolicy.chainMeetsPolicyRequirements(chain: chain) {
             return .failsToMeetPolicy(reason: reason)
         }
 

--- a/Tests/X509Tests/DNSNamesTests.swift
+++ b/Tests/X509Tests/DNSNamesTests.swift
@@ -258,43 +258,43 @@ final class DNSNamesTests: XCTestCase {
         XCTAssertEqual(reverse(".example.com"), ["com", "example", ""])
     }
 
+    static func urisThatMatch(_ dnsName: String) -> [String] {
+        return [
+            "http://\(dnsName)/",
+            "https://\(dnsName)",
+            "http://user:password@\(dnsName)",
+            "http://\(dnsName)/index.html",
+            "https://\(dnsName)/foo/bar/baz?x=y",
+            "ftp://user:password@\(dnsName):4343/cat.txt",
+        ]
+    }
+
+    static func urisThatDontMatch(_ dnsName: String) -> [String] {
+        return [
+            // User and password parts don't match.
+            "http://\(dnsName):\(dnsName)@sir.not.appearing.in.this.movie",
+
+            // Scheme doesn't match
+            "\(dnsName)://sir.not.appearing.in.this.movie/",
+
+            // Path doesn't match
+            "http://sir.not.appearing.in.this.movie/\(dnsName)/baz",
+
+            // IP addresses never match
+            "http://127.0.0.1",
+            "http://[fe80::1]",
+
+            // Neither do URIs without host components at all
+            "/foo/bar",
+            "\(dnsName)",
+        ]
+    }
+
     func testURINamesMatchReferenceHostname() throws {
         // This adapts the basic checks from the DNS name case, as they apply to the host part of the constraint. However,
         // to each case we add a little URI special sauce to confirm that they all still work (or don't!).
-        func urisThatMatch(_ dnsName: String) -> [String] {
-            return [
-                "http://\(dnsName)/",
-                "https://\(dnsName)",
-                "http://user:password@\(dnsName)",
-                "http://\(dnsName)/index.html",
-                "https://\(dnsName)/foo/bar/baz?x=y",
-                "ftp://user:password@\(dnsName):4343/cat.txt",
-            ]
-        }
-
-        func urisThatDontMatch(_ dnsName: String) -> [String] {
-            return [
-                // User and password parts don't match.
-                "http://\(dnsName):\(dnsName)@sir.not.appearing.in.this.movie",
-
-                // Scheme doesn't match
-                "\(dnsName)://sir.not.appearing.in.this.movie/",
-
-                // Path doesn't match
-                "http://sir.not.appearing.in.this.movie/\(dnsName)/baz",
-
-                // IP addresses never match
-                "http://127.0.0.1",
-                "http://[fe80::1]",
-
-                // Neither do URIs without host components at all
-                "/foo/bar",
-                "\(dnsName)",
-            ]
-        }
-
         for (dnsName, constraint, match) in DNSNamesTests.fixtures {
-            for uri in urisThatMatch(dnsName) {
+            for uri in DNSNamesTests.urisThatMatch(dnsName) {
                 XCTAssertEqual(
                     match,
                     NameConstraintsPolicy.uriNameMatchesConstraint(uriName: uri, constraint: constraint),
@@ -313,7 +313,7 @@ final class DNSNamesTests: XCTestCase {
                 continue
             }
 
-            for uri in urisThatDontMatch(dnsName) {
+            for uri in DNSNamesTests.urisThatDontMatch(dnsName) {
                 XCTAssertFalse(
                     NameConstraintsPolicy.uriNameMatchesConstraint(uriName: uri, constraint: constraint),
                     "\(uri) incorrectly matched \(constraint)"

--- a/Tests/X509Tests/NameConstraintsTests.swift
+++ b/Tests/X509Tests/NameConstraintsTests.swift
@@ -17,29 +17,29 @@ import SwiftASN1
 @testable import X509
 
 final class NameConstraintsTests: XCTestCase {
+    static let names: [DistinguishedName] = [
+        try! DistinguishedName {
+            CountryName("US")
+            StateOrProvinceName("CA")
+            OrganizationName("Apple")
+        },
+        try! DistinguishedName {
+            CountryName("US")
+            StateOrProvinceName("CA")
+            OrganizationName("Apple")
+            CommonName("Test")
+        },
+        try! DistinguishedName {
+            CountryName("GB")
+            OrganizationName("Apple")
+            CommonName("Test")
+        },
+    ]
+
     func testDirectoryNameMatches() throws {
         // The key here is that a distinguished name only matches a constraint if they're equal.
-        let names: [DistinguishedName] = [
-            try DistinguishedName {
-                CountryName("US")
-                StateOrProvinceName("CA")
-                OrganizationName("Apple")
-            },
-            try DistinguishedName {
-                CountryName("US")
-                StateOrProvinceName("CA")
-                OrganizationName("Apple")
-                CommonName("Test")
-            },
-            try DistinguishedName {
-                CountryName("GB")
-                OrganizationName("Apple")
-                CommonName("Test")
-            },
-        ]
-
-        for firstName in names {
-            for secondName in names {
+        for firstName in NameConstraintsTests.names {
+            for secondName in NameConstraintsTests.names {
                 XCTAssertEqual(
                     NameConstraintsPolicy.directoryNameMatchesConstraint(directoryName: firstName, constraint: secondName),
                     firstName == secondName,

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -665,9 +665,7 @@ final class RFC5280PolicyTests: XCTestCase {
                 Critical(
                     BasicConstraints.isCertificateAuthority(maxPathLength: 0)
                 )
-                if let subjectAlternativeNames {
-                    SubjectAlternativeNames(subjectAlternativeNames)
-                }
+                SubjectAlternativeNames(subjectAlternativeNames)
             },
             issuer: .unconstrainedRoot
         )

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -567,9 +567,7 @@ final class RFC5280PolicyTests: XCTestCase {
                 Critical(
                     BasicConstraints.isCertificateAuthority(maxPathLength: 0)
                 )
-                if let subjectAlternativeNames {
-                    SubjectAlternativeNames(subjectAlternativeNames)
-                }
+                SubjectAlternativeNames(subjectAlternativeNames)
             },
             issuer: .unconstrainedRoot
         )


### PR DESCRIPTION
This patch ties together the various checks we have already written into a single NameConstraintsPolicy, and attaches it to the RFC5280Policy. This includes defining the logic for traversing names, as well as for managing the excluded and permitted subtrees.

Unfortunately, this patch is giant. I wish I could do more about it, but fundamentally the majority of the code it adds is tests, and those tests are all necessary.