### PR TITLE
Add support for policing critical extensions

### DIFF
--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -112,7 +112,7 @@ enum OCSPRequestHashAlgorithm {
     }
 }
 
-public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy, Sendable {
+public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy {
     public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
     
     private var requester: Requester

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -38,6 +38,8 @@ extension ASN1ObjectIdentifier {
 }
 
 struct OCSPResponderSigningPolicy: VerifierPolicy {
+    let processedExtensions: [ASN1ObjectIdentifier] = []
+
     /// direct issuer of the certificate for which we check the OCSP status for
     var issuer: Certificate
     mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
@@ -110,7 +112,8 @@ enum OCSPRequestHashAlgorithm {
     }
 }
 
-public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy {
+public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy, Sendable {
+    public let processedExtensions: [ASN1ObjectIdentifier] = []
     
     private var requester: Requester
     private var requestHashAlgorithm: OCSPRequestHashAlgorithm

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -38,7 +38,7 @@ extension ASN1ObjectIdentifier {
 }
 
 struct OCSPResponderSigningPolicy: VerifierPolicy {
-    let processedExtensions: [ASN1ObjectIdentifier] = []
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
     /// direct issuer of the certificate for which we check the OCSP status for
     var issuer: Certificate
@@ -113,7 +113,7 @@ enum OCSPRequestHashAlgorithm {
 }
 
 public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy, Sendable {
-    public let processedExtensions: [ASN1ObjectIdentifier] = []
+    public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
     
     private var requester: Requester
     private var requestHashAlgorithm: OCSPRequestHashAlgorithm

--- a/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
@@ -18,7 +18,7 @@ import SwiftASN1
 @usableFromInline
 struct BasicConstraintsPolicy: VerifierPolicy {
     @usableFromInline
-    let processedExtensions: [ASN1ObjectIdentifier] = [
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
         .X509ExtensionID.basicConstraints
     ]
 

--- a/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
@@ -12,10 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
+import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices the basicConstraints extension.
 @usableFromInline
 struct BasicConstraintsPolicy: VerifierPolicy {
+    @usableFromInline
+    let processedExtensions: [ASN1ObjectIdentifier] = [
+        .X509ExtensionID.basicConstraints
+    ]
+
     @inlinable
     init() { }
 

--- a/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
@@ -19,7 +19,7 @@ import SwiftASN1
 @usableFromInline
 struct ExpiryPolicy: VerifierPolicy {
     @usableFromInline
-    let processedExtensions: [ASN1ObjectIdentifier] = []
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
     @usableFromInline
     let validationTime: Date

--- a/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
@@ -13,10 +13,14 @@
 //===----------------------------------------------------------------------===//
 
 import Foundation
+import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices expiry.
 @usableFromInline
 struct ExpiryPolicy: VerifierPolicy {
+    @usableFromInline
+    let processedExtensions: [ASN1ObjectIdentifier] = []
+
     @usableFromInline
     let validationTime: Date
 

--- a/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
@@ -12,10 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
+import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices the nameConstraints extension.
 @usableFromInline
 struct NameConstraintsPolicy: VerifierPolicy {
+    @usableFromInline
+    let processedExtensions: [ASN1ObjectIdentifier] = [
+        .X509ExtensionID.nameConstraints
+    ]
+
     @inlinable
     init() { }
 

--- a/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
@@ -18,7 +18,7 @@ import SwiftASN1
 @usableFromInline
 struct NameConstraintsPolicy: VerifierPolicy {
     @usableFromInline
-    let processedExtensions: [ASN1ObjectIdentifier] = [
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
         .X509ExtensionID.nameConstraints
     ]
 

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -21,7 +21,7 @@ import SwiftASN1
 ///
 /// 1. Expiry. Expired certificates are rejected.
 public struct RFC5280Policy: VerifierPolicy {
-    public let processedExtensions: [ASN1ObjectIdentifier] = [
+    public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
         .X509ExtensionID.basicConstraints,
         .X509ExtensionID.nameConstraints,
 

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
+import SwiftASN1
 
 /// A ``VerifierPolicy`` that implements the core chain verifying policies from RFC 5280.
 ///
@@ -20,6 +21,20 @@ import Foundation
 ///
 /// 1. Expiry. Expired certificates are rejected.
 public struct RFC5280Policy: VerifierPolicy {
+    public let processedExtensions: [ASN1ObjectIdentifier] = [
+        .X509ExtensionID.basicConstraints,
+        .X509ExtensionID.nameConstraints,
+
+        // The presence of keyUsage here requires some explanation, becuase this policy doesn't _actually_ compute
+        // on it in any way.
+        //
+        // The unfortunate reality of keyUsage is that, while RFC 5280 requires us to validate it, CAs have historically
+        // done a very poor job of actually implementing it. The result is that policing KeyUsage produces minimal value
+        // in terms of increased security, but produces a substantial uptick in the number of unbuildable chains. So
+        // we _pretend_ to police the key usage, and just...don't.
+        .X509ExtensionID.keyUsage
+    ]
+
     @usableFromInline
     let expiryPolicy: ExpiryPolicy
 

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -29,7 +29,13 @@ public struct Verifier {
 
         var policyFailures: [VerificationResult.PolicyFailure] = []
 
-        // First check: is this leaf _already in_ the certificate store? If it is, we can just trust it directly.
+        // First check: does this leaf certificate contain critical extensions that are not satisfied by the policyset?
+        // If so, reject the chain.
+        if leafCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.processedExtensions) {
+            return .couldNotValidate([])
+        }
+
+        // Second check: is this leaf _already in_ the certificate store? If it is, we can just trust it directly.
         //
         // Note that this requires an _exact match_: if there isn't an exact match, we'll fall back to chain building,
         // which may let us chain through another variant of this certificate and build a valid chain. This is a very

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -31,7 +31,7 @@ public struct Verifier {
 
         // First check: does this leaf certificate contain critical extensions that are not satisfied by the policyset?
         // If so, reject the chain.
-        if leafCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.processedExtensions) {
+        if leafCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.verifyingCriticalExtensions) {
             return .couldNotValidate([])
         }
 
@@ -101,7 +101,7 @@ public struct Verifier {
 
     private func shouldSkipAddingCertificate(partialChain: CandidatePartialChain, nextCertificate: Certificate) -> Bool {
         // We want to confirm that the certificate has no unhandled critical extensions. If it does, we can't build the chain.
-        if nextCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.processedExtensions) {
+        if nextCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.verifyingCriticalExtensions) {
             return true
         }
 

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import SwiftASN1
 
 public struct Verifier {
     public var rootCertificates: CertificateStore
@@ -57,7 +58,7 @@ public struct Verifier {
 
                 // Each of these is now potentially a valid unverified chain.
                 for root in rootParents {
-                    if Self.shouldSkipAddingCertificate(partialChain: nextPartialCandidate, nextCertificate: root) {
+                    if self.shouldSkipAddingCertificate(partialChain: nextPartialCandidate, nextCertificate: root) {
                         continue
                     }
 
@@ -79,7 +80,7 @@ public struct Verifier {
                 intermediateParents.sortBySuitabilityForIssuing(certificate: nextPartialCandidate.currentTip)
 
                 for parent in intermediateParents {
-                    if Self.shouldSkipAddingCertificate(partialChain: nextPartialCandidate, nextCertificate: parent) {
+                    if self.shouldSkipAddingCertificate(partialChain: nextPartialCandidate, nextCertificate: parent) {
                         continue
                     }
 
@@ -92,7 +93,12 @@ public struct Verifier {
         return .couldNotValidate(policyFailures)
     }
 
-    private static func shouldSkipAddingCertificate(partialChain: CandidatePartialChain, nextCertificate: Certificate) -> Bool {
+    private func shouldSkipAddingCertificate(partialChain: CandidatePartialChain, nextCertificate: Certificate) -> Bool {
+        // We want to confirm that the certificate has no unhandled critical extensions. If it does, we can't build the chain.
+        if nextCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.processedExtensions) {
+            return true
+        }
+
         // We don't want to re-add the same certificate to the chain: that will always produce a chain that
         // could have been shorter.
         if partialChain.contains(certificate: nextCertificate) {
@@ -194,6 +200,16 @@ extension Certificate {
 
         // The SKI is present. If the two match, this is higher preference: if they don't match, it's lower.
         return subjectAKI.keyIdentifier == ski.keyIdentifier ? 1 : -1
+    }
+
+    func hasUnhandledCriticalExtensions(handledExtensions: [ASN1ObjectIdentifier]) -> Bool {
+        for ext in self.extensions where ext.critical {
+            guard handledExtensions.contains(ext.oid) else {
+                return true
+            }
+        }
+
+        return false
     }
 }
 

--- a/Sources/X509/Verifier/VerifierPolicy.swift
+++ b/Sources/X509/Verifier/VerifierPolicy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2022-2023 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -11,8 +11,45 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import SwiftASN1
 
+/// A ``VerifierPolicy`` implements a series of checks on an ``UnverifiedCertificateChain`` in order to determine
+/// whether that chain should be trusted.
+///
+/// Certificate verification is split into two parts: chain building and policy enforcement. Chain building is general:
+/// regardless of policy, we use the same chain building algorithm. This will generate a sequence of candidate chains in
+/// the form of ``UnverifiedCertificateChain``.
+///
+/// Each of these candidate chains is then handed to a ``PolicySet`` to be checked against the certificate policy.
+/// The reason for this is to allow different use-cases to share the same chain building code, but to enforce
+/// different requirements on the chain.
+///
+/// Some ``VerifierPolicy`` objects are used frequently and are very common, such as ``RFC5280Policy`` which implements
+/// the basic checks from that RFC. Other objects are less common, such as ``OCSPVerifierPolicy``, which performs live
+/// revocation checking. Users can also implement their own policies to enable swift-certificates to support other
+/// use-cases.
 public protocol VerifierPolicy {
+    /// The X.509 extension types that this policy understands and enforces.
+    ///
+    /// X.509 certificates can have extensions marked as `critical`. These extensions _must_ be understood and enforced by the
+    /// verifier. If they aren't understood or processed, then verifying the chain must fail.
+    ///
+    /// ``Verifier`` uses the ``VerifierPolicy/processedExtensions`` field to determine what extensions are understood by a given
+    /// ``PolicySet``. A ``PolicySet`` understands the union of all the understood extensions of its contained ``VerifierPolicy``
+    /// objects.
+    ///
+    /// This may be an empty array, if the policy does not concern itself with any particular extensions. Users must only put
+    /// an extension value in this space if they are actually enforcing the rules of that particular extension value.
+    var processedExtensions: [ASN1ObjectIdentifier] { get }
+
+    /// Called to determine whether a given ``UnverifiedCertificateChain`` meets the requirements of this policy.
+    ///
+    /// Certificate verification is split into two parts: chain building and policy enforcement. Chain building is general:
+    /// regardless of policy, we use the same chain building algorithm. This will generate a sequence of candidate chains in
+    /// the form of ``UnverifiedCertificateChain``.
+    ///
+    /// Each of these candidate chains is then handed to a ``PolicySet`` to be checked against the certificate policy.
+    /// The checking is done in this method.
     mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult
 }
 
@@ -27,11 +64,22 @@ public enum PolicyEvaluationResult: Sendable {
 // Additionally, we should add conditional Sendable, Equatable, and Hashable conformances as needed.
 // This will also allow equivalent conditional conformances on `Verifier`.
 public struct PolicySet: VerifierPolicy {
+    public let processedExtensions: [ASN1ObjectIdentifier]
+
     @usableFromInline var policies: [any VerifierPolicy]
 
     @inlinable
     public init(policies: [any VerifierPolicy]) {
         self.policies = policies
+
+        var extensions: [ASN1ObjectIdentifier] = []
+        extensions.reserveCapacity(policies.reduce(into: 0, { $0 += $1.processedExtensions.count }))
+
+        for policy in policies {
+            extensions.append(contentsOf: policy.processedExtensions)
+        }
+
+        self.processedExtensions = extensions
     }
 
     public mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
@@ -51,4 +99,3 @@ public struct PolicySet: VerifierPolicy {
         return .meetsPolicy
     }
 }
-

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -327,7 +327,7 @@ final class CMSTests: XCTestCase {
 
     func testPoliciesAreApplied() async throws {
         final class RejectAllPolicy: VerifierPolicy {
-            let processedExtensions: [ASN1ObjectIdentifier] = []
+            let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
             
             func chainMeetsPolicyRequirements(chain: X509.UnverifiedCertificateChain) async -> X509.PolicyEvaluationResult {
                 return .failsToMeetPolicy(reason: "all chains are forbidden")

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -128,6 +128,10 @@ final class CMSTests: XCTestCase {
         issuerPrivateKey: intermediateKey
     )
 
+    static var defaultPolicies: PolicySet {
+        PolicySet(policies: [RFC5280Policy(validationTime: Date())])
+    }
+
     private func assertRoundTrips<ASN1Object: DERParseable & DERSerializable & Equatable>(_ value: ASN1Object) throws {
         var serializer = DER.Serializer()
         try serializer.serialize(value)
@@ -309,7 +313,7 @@ final class CMSTests: XCTestCase {
         let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 
         let signature = try CMS.sign(data, signatureAlgorithm: .ecdsaWithSHA256, certificate: Self.leaf1Cert, privateKey: Self.leaf1Key)
-        let isValidSignature = await CMS.isValidSignature(dataBytes: data, signatureBytes: signature, trustRoots: CertificateStore([Self.rootCert]), policy: PolicySet(policies: []))
+        let isValidSignature = await CMS.isValidSignature(dataBytes: data, signatureBytes: signature, trustRoots: CertificateStore([Self.rootCert]), policy: Self.defaultPolicies)
         XCTAssertValidSignature(isValidSignature)
     }
 
@@ -323,6 +327,8 @@ final class CMSTests: XCTestCase {
 
     func testPoliciesAreApplied() async throws {
         final class RejectAllPolicy: VerifierPolicy {
+            let processedExtensions: [ASN1ObjectIdentifier] = []
+            
             func chainMeetsPolicyRequirements(chain: X509.UnverifiedCertificateChain) async -> X509.PolicyEvaluationResult {
                 return .failsToMeetPolicy(reason: "all chains are forbidden")
             }
@@ -539,7 +545,7 @@ final class CMSTests: XCTestCase {
             signatureBytes: signature,
             additionalIntermediateCertificates: [Self.intermediateCert],
             trustRoots: CertificateStore([Self.rootCert]),
-            policy: PolicySet(policies: [])
+            policy: Self.defaultPolicies
         )
         XCTAssertValidSignature(isValidSignature)
     }
@@ -558,7 +564,7 @@ final class CMSTests: XCTestCase {
             dataBytes: data,
             signatureBytes: signature,
             trustRoots: CertificateStore([Self.rootCert]),
-            policy: PolicySet(policies: [])
+            policy: Self.defaultPolicies
         )
         XCTAssertValidSignature(isValidSignature)
     }
@@ -578,7 +584,7 @@ final class CMSTests: XCTestCase {
             signatureBytes: signature,
             additionalIntermediateCertificates: [Self.intermediateCert],
             trustRoots: CertificateStore([Self.rootCert]),
-            policy: PolicySet(policies: [])
+            policy: Self.defaultPolicies
         )
         XCTAssertValidSignature(isValidSignature)
     }

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -30,11 +30,33 @@ final class RFC5280PolicyTests: XCTestCase {
             case .rfc5280:
                 return RFC5280Policy(validationTime: validationTime)
             case .expiry:
-                return ExpiryPolicy(validationTime: validationTime)
+                return PolicySet(policies: [
+                    ExpiryPolicy(validationTime: validationTime),
+                    CatchAllPolicy()
+                ])
             case .basicConstraints:
-                return BasicConstraintsPolicy()
+                return PolicySet(policies: [
+                    BasicConstraintsPolicy(),
+                    CatchAllPolicy()
+                ])
             case .nameConstraints:
-                return NameConstraintsPolicy()
+                return PolicySet(policies: [
+                    NameConstraintsPolicy(),
+                    CatchAllPolicy()
+                ])
+            }
+        }
+
+        // This do-nothing policy
+        struct CatchAllPolicy: VerifierPolicy {
+            let processedExtensions: [ASN1ObjectIdentifier] = [
+                .X509ExtensionID.basicConstraints,
+                .X509ExtensionID.nameConstraints,
+                .X509ExtensionID.keyUsage
+            ]
+
+            func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+                return .meetsPolicy
             }
         }
     }
@@ -1202,6 +1224,45 @@ final class RFC5280PolicyTests: XCTestCase {
 
     func testExcludedSubtreesBeatPermittedSubtreesBasePolicy() async throws {
         try await self.excludedSubtreesBeatPermittedSubtrees(.nameConstraints)
+    }
+
+    func testIgnoresKeyUsage() async throws {
+        // This test doesn't have a base policy version, only the combined policy does this.
+        let alternativeIntermediate = TestPKI.issueIntermediate(
+            name: TestPKI.unconstrainedIntermediateName,
+            key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+            extensions: try! Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+
+                // This key usage is forbidden by RFC 5280 in the context of an intermediate:
+                //
+                //   If the keyUsage extension is present, then the subject public key
+                //   MUST NOT be used to verify signatures on certificates or CRLs unless
+                //   the corresponding keyCertSign or cRLSign bit is set.
+                //
+                // We don't care here.
+                Critical(
+                    KeyUsage(digitalSignature: true)
+                )
+            },
+            issuer: .unconstrainedRoot
+        )
+
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(issuer: .unconstrainedIntermediate)
+
+        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: Date())]))
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([alternativeIntermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, alternativeIntermediate, TestPKI.unconstrainedCA])
+
     }
 }
 

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -49,7 +49,7 @@ final class RFC5280PolicyTests: XCTestCase {
 
         // This do-nothing policy
         struct CatchAllPolicy: VerifierPolicy {
-            let processedExtensions: [ASN1ObjectIdentifier] = [
+            let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
                 .X509ExtensionID.basicConstraints,
                 .X509ExtensionID.nameConstraints,
                 .X509ExtensionID.keyUsage

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -19,6 +19,8 @@ import X509
 import Crypto
 
 final class VerifierTests: XCTestCase {
+    private static let referenceTime = Date()
+
     private static let ca1PrivateKey = P384.Signing.PrivateKey()
     private static let ca1Name = try! DistinguishedName {
         CountryName("US")
@@ -30,8 +32,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(ca1PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(3650),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(3650),
             issuer: ca1Name,
             subject: ca1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -50,8 +52,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(ca1PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(365),
             issuer: ca2Name,
             subject: ca1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -72,8 +74,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(ca1AlternativePrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(3650),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(3650),
             issuer: ca1Name,
             subject: ca1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -99,8 +101,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(ca2PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(3650),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(3650),
             issuer: ca2Name,
             subject: ca2Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -119,8 +121,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(ca2PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(365),
             issuer: ca1Name,
             subject: ca2Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -147,8 +149,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(intermediate1PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: ca1.subject,
             subject: intermediate1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -168,8 +170,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(intermediate1PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: ca1.subject,
             subject: intermediate1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -187,8 +189,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(intermediate1PrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: ca1.subject,
             subject: intermediate1Name,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -216,8 +218,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(localhostLeafPrivateKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(365),
             issuer: intermediate1.subject,
             subject: localhostLeafName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -244,8 +246,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(isolatedSelfSignedCertKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(365),
             issuer: isolatedSelfSignedCertName,
             subject: isolatedSelfSignedCertName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -338,8 +340,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(t1t2Key.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: ca1.subject,
             subject: tName,
             signatureAlgorithm: .ecdsaWithSHA384,
@@ -362,8 +364,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(t1t2Key.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: xName,
             subject: tName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -381,8 +383,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(t3Key.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: xName,
             subject: tName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -401,8 +403,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(xKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: tName,
             subject: xName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -421,8 +423,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(xKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: tName,
             subject: xName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -442,8 +444,8 @@ final class VerifierTests: XCTestCase {
             version: .v3,
             serialNumber: .init(),
             publicKey: .init(insaneLeafKey.publicKey),
-            notValidBefore: Date() - .days(365),
-            notValidAfter: Date() + .days(5 * 365),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(5 * 365),
             issuer: tName,
             subject: leafName,
             signatureAlgorithm: .ecdsaWithSHA256,
@@ -457,10 +459,14 @@ final class VerifierTests: XCTestCase {
         )
     }()
 
+    private static var defaultPolicy: PolicySet {
+        PolicySet(policies: [RFC5280Policy(validationTime: referenceTime)])
+    }
+
     func testTrivialChainBuilding() async throws {
         let roots = CertificateStore([Self.ca1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -474,7 +480,7 @@ final class VerifierTests: XCTestCase {
     func testMissingIntermediateFailsToBuild() async throws {
         let roots = CertificateStore([Self.ca1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([]))
 
         guard case .couldNotValidate(let policyResults) = result else {
@@ -488,7 +494,7 @@ final class VerifierTests: XCTestCase {
     func testMissingRootFailsToBuild() async throws {
         let roots = CertificateStore([])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .couldNotValidate(let policyResults) = result else {
@@ -502,7 +508,7 @@ final class VerifierTests: XCTestCase {
     func testExtraRootsAreIgnored() async throws {
         let roots = CertificateStore([Self.ca1, Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -516,7 +522,7 @@ final class VerifierTests: XCTestCase {
     func testPuttingRootsInTheIntermediariesIsntAProblem() async throws {
         let roots = CertificateStore([Self.ca1, Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1, Self.ca1, Self.ca2]))
 
         guard case .validCertificate(let chain) = result else {
@@ -530,7 +536,7 @@ final class VerifierTests: XCTestCase {
     func testSupportsCrossSignedRootWithoutTrouble() async throws {
         let roots = CertificateStore([Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1, Self.ca1CrossSignedByCA2]))
 
         guard case .validCertificate(let chain) = result else {
@@ -544,7 +550,7 @@ final class VerifierTests: XCTestCase {
     func testBuildsTheShorterPathInTheCaseOfCrossSignedRoots() async throws {
         let roots = CertificateStore([Self.ca1, Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1, Self.ca2CrossSignedByCA1, Self.ca1CrossSignedByCA2]))
 
         guard case .validCertificate(let chain) = result else {
@@ -558,7 +564,7 @@ final class VerifierTests: XCTestCase {
     func testPrefersToUseIntermediatesWithSKIThatMatches() async throws {
         let roots = CertificateStore([Self.ca1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1, Self.intermediate1WithoutSKIAKI]))
 
         guard case .validCertificate(let chain) = result else {
@@ -572,7 +578,7 @@ final class VerifierTests: XCTestCase {
     func testPrefersNoSKIToNonMatchingSKI() async throws {
         let roots = CertificateStore([Self.ca1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1WithIncorrectSKIAKI, Self.intermediate1WithoutSKIAKI]))
 
         guard case .validCertificate(let chain) = result else {
@@ -586,7 +592,7 @@ final class VerifierTests: XCTestCase {
     func testRejectsRootsThatDidNotSignTheCertBeforeThem() async throws {
         let roots = CertificateStore([Self.ca1WithAlternativePrivateKey, Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.ca1CrossSignedByCA2, Self.ca2CrossSignedByCA1, Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -600,7 +606,7 @@ final class VerifierTests: XCTestCase {
     func testPolicyFailuresCanFindLongerPaths() async throws {
         let roots = CertificateStore([Self.ca1, Self.ca2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [FailIfCertInChainPolicy(forbiddenCert: Self.ca1)]))
+        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [FailIfCertInChainPolicy(forbiddenCert: Self.ca1), Self.defaultPolicy]))
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1, Self.ca2CrossSignedByCA1, Self.ca1CrossSignedByCA2]))
 
         guard case .validCertificate(let chain) = result else {
@@ -615,7 +621,7 @@ final class VerifierTests: XCTestCase {
         let roots = CertificateStore([Self.ca1])
         let intermediates = CertificateStore([Self.t1, Self.t2, Self.t3, Self.x1, Self.x2])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.insaneLeaf, intermediates: intermediates)
 
         guard case .validCertificate(let chain) = result else {
@@ -629,7 +635,7 @@ final class VerifierTests: XCTestCase {
     func testSelfSignedCertsAreRejectedWhenNotInTheTrustStore() async throws {
         let roots = CertificateStore([Self.ca1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.isolatedSelfSignedCert, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .couldNotValidate = result else {
@@ -641,7 +647,7 @@ final class VerifierTests: XCTestCase {
     func testSelfSignedCertsAreTrustedWhenInTrustStore() async throws {
         let roots = CertificateStore([Self.ca1, Self.isolatedSelfSignedCert])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.isolatedSelfSignedCert, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -653,9 +659,18 @@ final class VerifierTests: XCTestCase {
     }
 
     func testTrustRootsCanBeNonSelfSignedLeaves() async throws {
+        // we use a custom policy here to ignore the fact that the basic constraints extension is critical.
+        struct IgnoreBasicConstraintsPolicy: VerifierPolicy {
+            let processedExtensions: [ASN1ObjectIdentifier] = [.X509ExtensionID.basicConstraints]
+
+            func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+                return .meetsPolicy
+            }
+        }
+
         let roots = CertificateStore([Self.localhostLeaf])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [IgnoreBasicConstraintsPolicy()]))
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -669,7 +684,7 @@ final class VerifierTests: XCTestCase {
     func testTrustRootsCanBeNonSelfSignedIntermediates() async throws {
         let roots = CertificateStore([Self.intermediate1])
 
-        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: []))
+        var verifier = Verifier(rootCertificates: roots, policy: Self.defaultPolicy)
         let result = await verifier.validate(leafCertificate: Self.localhostLeaf, intermediates: CertificateStore([Self.intermediate1]))
 
         guard case .validCertificate(let chain) = result else {
@@ -682,6 +697,8 @@ final class VerifierTests: XCTestCase {
 }
 
 fileprivate struct FailIfCalledPolicy: VerifierPolicy {
+    let processedExtensions: [ASN1ObjectIdentifier] = []
+
     mutating func chainMeetsPolicyRequirements(chain: X509.UnverifiedCertificateChain) async -> X509.PolicyEvaluationResult {
         XCTFail("Policy was called with chain \(chain)")
         return .failsToMeetPolicy(reason: "policy must not be called")
@@ -689,6 +706,8 @@ fileprivate struct FailIfCalledPolicy: VerifierPolicy {
 }
 
 fileprivate struct FailIfCertInChainPolicy: VerifierPolicy {
+    let processedExtensions: [ASN1ObjectIdentifier] = []
+
     private let forbiddenCert: Certificate
 
     init(forbiddenCert: Certificate) {

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -690,7 +690,7 @@ final class VerifierTests: XCTestCase {
     func testTrustRootsCanBeNonSelfSignedLeaves() async throws {
         // we use a custom policy here to ignore the fact that the basic constraints extension is critical.
         struct IgnoreBasicConstraintsPolicy: VerifierPolicy {
-            let processedExtensions: [ASN1ObjectIdentifier] = [.X509ExtensionID.basicConstraints]
+            let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [.X509ExtensionID.basicConstraints]
 
             func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
                 return .meetsPolicy
@@ -738,7 +738,7 @@ final class VerifierTests: XCTestCase {
 }
 
 fileprivate struct FailIfCalledPolicy: VerifierPolicy {
-    let processedExtensions: [ASN1ObjectIdentifier] = []
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
     mutating func chainMeetsPolicyRequirements(chain: X509.UnverifiedCertificateChain) async -> X509.PolicyEvaluationResult {
         XCTFail("Policy was called with chain \(chain)")
@@ -747,7 +747,7 @@ fileprivate struct FailIfCalledPolicy: VerifierPolicy {
 }
 
 fileprivate struct FailIfCertInChainPolicy: VerifierPolicy {
-    let processedExtensions: [ASN1ObjectIdentifier] = []
+    let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
     private let forbiddenCert: Certificate
 


### PR DESCRIPTION
We are required to ensure that we do not validate chains that contain certificates with extensions marked critical that we do not understand. Because we allow pluggable policies which can handle arbitrary extensions, we need a way to ask verifier policy objects what extensions they can handle.

This patch adds support for policies to express that set, as well as for the verifier to ensure that certificates that have critical extensions we cannot understand are not used for chain building. This is integrated early into chain building to reject unsatisfiable chains, and works transparently.

This PR also updates the tests to meet this new standard, including applying the RFC 5280 policy liberally throughout the test suite.