### PR TITLE
Tweak the ECDSA signature representation

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -85,6 +85,7 @@ add_library(X509
   "Verifier/Verifier.swift"
   "Verifier/VerifierPolicy.swift"
   "X509BaseTypes/AlgorithmIdentifier.swift"
+  "X509BaseTypes/ECDSASignature.swift"
   "X509BaseTypes/RSAPKCS1PublicKey.swift"
   "X509BaseTypes/SubjectPublicKeyInfo.swift"
   "X509BaseTypes/TBSCertificate.swift"

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -45,7 +45,9 @@ enum Digest {
 extension P256.Signing.PublicKey {
     @inlinable
     func isValidSignature(_ signature: Certificate.Signature, for digest: Digest) -> Bool {
-        guard case .p256(let innerSignature) = signature.backing else {
+        guard case .ecdsa(let rawInnerSignature) = signature.backing,
+              let innerSignature = P256.Signing.ECDSASignature(rawInnerSignature)
+        else {
             // Signature mismatch
             return false
         }
@@ -66,7 +68,9 @@ extension P256.Signing.PublicKey {
 extension P384.Signing.PublicKey {
     @inlinable
     func isValidSignature(_ signature: Certificate.Signature, for digest: Digest) -> Bool {
-        guard case .p384(let innerSignature) = signature.backing else {
+        guard case .ecdsa(let rawInnerSignature) = signature.backing,
+              let innerSignature = P384.Signing.ECDSASignature(rawInnerSignature)
+        else {
             // Signature mismatch
             return false
         }
@@ -87,7 +91,9 @@ extension P384.Signing.PublicKey {
 extension P521.Signing.PublicKey {
     @inlinable
     func isValidSignature(_ signature: Certificate.Signature, for digest: Digest) -> Bool {
-        guard case .p521(let innerSignature) = signature.backing else {
+        guard case .ecdsa(let rawInnerSignature) = signature.backing,
+              let innerSignature = P521.Signing.ECDSASignature(rawInnerSignature)
+        else {
             // Signature mismatch
             return false
         }
@@ -144,7 +150,7 @@ extension P256.Signing.PrivateKey {
             signature = try self.signature(for: sha512)
         }
 
-        return Certificate.Signature(backing: .p256(signature))
+        return Certificate.Signature(backing: .ecdsa(.init(signature)))
     }
 }
 
@@ -164,7 +170,7 @@ extension P384.Signing.PrivateKey {
             signature = try self.signature(for: sha512)
         }
 
-        return Certificate.Signature(backing: .p384(signature))
+        return Certificate.Signature(backing: .ecdsa(.init(signature)))
     }
 }
 
@@ -184,7 +190,7 @@ extension P521.Signing.PrivateKey {
             signature = try self.signature(for: sha512)
         }
 
-        return Certificate.Signature(backing: .p521(signature))
+        return Certificate.Signature(backing: .ecdsa(.init(signature)))
     }
 }
 

--- a/Sources/X509/X509BaseTypes/ECDSASignature.swift
+++ b/Sources/X509/X509BaseTypes/ECDSASignature.swift
@@ -1,0 +1,169 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import SwiftASN1
+import Crypto
+
+/// An ECDSA signature is laid out as follows:
+///
+/// ECDSASignature ::= SEQUENCE {
+///   r INTEGER,
+///   s INTEGER
+/// }
+///
+/// We define this type here because an X.509 certificate may have an ECDSA signature
+/// in it without reference to what key created it. We need to be able to store it
+/// abstractly, and then turn it into the signature type we need on request.
+@usableFromInline
+struct ECDSASignature: DERImplicitlyTaggable, Hashable, Sendable {
+    @inlinable
+    static var defaultIdentifier: ASN1Identifier {
+        .sequence
+    }
+
+    @usableFromInline
+    var r: ArraySlice<UInt8>
+
+    @usableFromInline
+    var s: ArraySlice<UInt8>
+
+    @inlinable
+    init(r: ArraySlice<UInt8>, s: ArraySlice<UInt8>) {
+        self.r = r
+        self.s = s
+    }
+
+    @inlinable
+    init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
+        self = try DER.sequence(rootNode, identifier: identifier) { nodes in
+            let r = try ArraySlice<UInt8>(derEncoded: &nodes)
+            let s = try ArraySlice<UInt8>(derEncoded: &nodes)
+
+            return ECDSASignature(r: r, s: s)
+        }
+    }
+
+    @inlinable
+    func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
+        try coder.appendConstructedNode(identifier: identifier) { coder in
+            try coder.serialize(self.r)
+            try coder.serialize(self.s)
+        }
+    }
+
+    @inlinable
+    init(rawSignatureBytes raw: Data) {
+        let half = raw.count / 2
+        let r = Array(raw.prefix(upTo: half))[...]
+        let s = Array(raw.suffix(from: half))[...]
+
+        self = ECDSASignature(r: r, s: s)
+    }
+
+    @inlinable
+    init(_ sig: P256.Signing.ECDSASignature) {
+        self = .init(rawSignatureBytes: sig.rawRepresentation)
+    }
+
+    @inlinable
+    init(_ sig: P384.Signing.ECDSASignature) {
+        self = .init(rawSignatureBytes: sig.rawRepresentation)
+    }
+
+    @inlinable
+    init(_ sig: P521.Signing.ECDSASignature) {
+        self = .init(rawSignatureBytes: sig.rawRepresentation)
+    }
+}
+
+extension P256.Signing.ECDSASignature {
+    @inlinable
+    init?(_ signature: ECDSASignature) {
+        let coordinateByteCount = 32
+
+        guard signature.r.count <= coordinateByteCount && signature.s.count <= coordinateByteCount else {
+            return nil
+        }
+
+        // r and s must be padded out to the coordinate byte count.
+        // We use Data here because Crypto wants that type anyway.
+        var raw = Data()
+        raw.reserveCapacity(2 * coordinateByteCount)
+
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.r.count))
+        raw.append(contentsOf: signature.r)
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.s.count))
+        raw.append(contentsOf: signature.s)
+
+        do {
+            self = try .init(rawRepresentation: raw)
+        } catch {
+            return nil
+        }
+    }
+}
+
+extension P384.Signing.ECDSASignature {
+    @inlinable
+    init?(_ signature: ECDSASignature) {
+        let coordinateByteCount = 48
+
+        guard signature.r.count <= coordinateByteCount && signature.s.count <= coordinateByteCount else {
+            return nil
+        }
+
+        // r and s must be padded out to the coordinate byte count.
+        // We use Data here because Crypto wants that type anyway.
+        var raw = Data()
+        raw.reserveCapacity(2 * coordinateByteCount)
+
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.r.count))
+        raw.append(contentsOf: signature.r)
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.s.count))
+        raw.append(contentsOf: signature.s)
+
+        do {
+            self = try .init(rawRepresentation: raw)
+        } catch {
+            return nil
+        }
+    }
+}
+
+extension P521.Signing.ECDSASignature {
+    @inlinable
+    init?(_ signature: ECDSASignature) {
+        let coordinateByteCount = 66
+
+        guard signature.r.count <= coordinateByteCount && signature.s.count <= coordinateByteCount else {
+            return nil
+        }
+
+        // r and s must be padded out to the coordinate byte count.
+        // We use Data here because Crypto wants that type anyway.
+        var raw = Data()
+        raw.reserveCapacity(2 * coordinateByteCount)
+
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.r.count))
+        raw.append(contentsOf: signature.r)
+        raw.append(contentsOf: repeatElement(0, count: coordinateByteCount - signature.s.count))
+        raw.append(contentsOf: signature.s)
+
+        do {
+            self = try .init(rawRepresentation: raw)
+        } catch {
+            return nil
+        }
+    }
+}

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -369,4 +369,111 @@ final class CertificateDERTests: XCTestCase {
         let newKey = try Certificate.PublicKey(spki: decodedSPKI)
         XCTAssertEqual(publicKey, newKey)
     }
+
+    func testIncorrectParameterSize() throws {
+        // This certificate tripped us up and revealed a bug in our ECDSA
+        // parsing, so let's use it as a regression test.
+        let cert = Array(Data(base64Encoded: """
+            MIIGATCCBYegAwIBAgIRAJt9HrGyczJOAAAAAFaglHwwCgYIKoZIzj0EAwIwgbox
+            CzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1FbnRydXN0LCBJbmMuMSgwJgYDVQQLEx9T
+            ZWUgd3d3LmVudHJ1c3QubmV0L2xlZ2FsLXRlcm1zMTkwNwYDVQQLEzAoYykgMjAx
+            NiBFbnRydXN0LCBJbmMuIC0gZm9yIGF1dGhvcml6ZWQgdXNlIG9ubHkxLjAsBgNV
+            BAMTJUVudHJ1c3QgQ2VydGlmaWNhdGlvbiBBdXRob3JpdHkgLSBMMUowHhcNMTkx
+            MTEzMDc0MTIwWhcNMjIwMjExMDgxMTE4WjCBpTELMAkGA1UEBhMCU0cxEjAQBgNV
+            BAcTCVNpbmdhcG9yZTETMBEGCysGAQQBgjc8AgEDEwJTRzEcMBoGA1UEChMTVGVt
+            YXNlayBQb2x5dGVjaG5pYzEaMBgGA1UEDxMRR292ZXJubWVudCBFbnRpdHkxEzAR
+            BgNVBAUTClQwOEdCMDA2MkwxHjAcBgNVBAMTFWlzaXMzb3NzY2V0LnRwLmVkdS5z
+            ZzBZMBMGByqGSM49AgEGCCqGSM49AwEHA0IABM2mA20fTxL81TOzHToOMpROOoUO
+            FVwGtdjQlCsN5TQ05Oazts57Cam4TRV437nibW2pHbv4Z6gX5cOj5vtGJFijggN/
+            MIIDezAgBgNVHREEGTAXghVpc2lzM29zc2NldC50cC5lZHUuc2cwggH1BgorBgEE
+            AdZ5AgQCBIIB5QSCAeEB3wB1AId1v+dZfPiMQ5lfvfNu/1aNR1Y2/0q1YMG06v9e
+            oIMPAAABbmPRJr0AAAQDAEYwRAIgDQlMMVr0sZ/vQ6TJayUKr/0uli6JsMdXra7+
+            AXtTAuACIHCqklPVac2HyjMHIcmB9Z9Ff/qdm80cTnJv2D2DF4f1AHYAVYHUwhaQ
+            NgFK6gubVzxT8MDkOHhwJQgXL6OqHQcT0wwAAAFuY9Em+QAABAMARzBFAiBlwOv7
+            uk+wVGWXmZur2HNFHUpY3EL72A6qp0+i+UlNKgIhAPUM6StlYsDeHFBcbwk8Mhsy
+            qvJ/cONzlQoi7aXSKen4AHYAVhQGmi/XwuzT9eG9RLI+x0Z2ubyZEVzA75SYVdaJ
+            0N0AAAFuY9Em+wAABAMARzBFAiAYjMoE9baPZ9jtoL5cLi2hEQFcHmp2V/UkF5gS
+            MCkHbwIhAN0mbQvKboODaXXfPf3K9F5mRks2NYdrpV7I+uTsxxcwAHYAu9nfvB+K
+            cbWTlCOXqpJ7RzhXlQqrUugakJZkNo4e0YUAAAFuY9EmtwAABAMARzBFAiEAocip
+            srDjKmlOd8Zo+mhFFVRmZYlgZMoLV/IvrMTEAFMCIFfzmKsxybQnMGX6iPbTU7nk
+            kAtsnNa6QaTEpRMVmsSEMA4GA1UdDwEB/wQEAwIHgDAdBgNVHSUEFjAUBggrBgEF
+            BQcDAQYIKwYBBQUHAwIwYwYIKwYBBQUHAQEEVzBVMCMGCCsGAQUFBzABhhdodHRw
+            Oi8vb2NzcC5lbnRydXN0Lm5ldDAuBggrBgEFBQcwAoYiaHR0cDovL2FpYS5lbnRy
+            dXN0Lm5ldC9sMWotZWMxLmNlcjAzBgNVHR8ELDAqMCigJqAkhiJodHRwOi8vY3Js
+            LmVudHJ1c3QubmV0L2xldmVsMWouY3JsMEoGA1UdIARDMEEwNgYKYIZIAYb6bAoB
+            AjAoMCYGCCsGAQUFBwIBFhpodHRwOi8vd3d3LmVudHJ1c3QubmV0L3JwYTAHBgVn
+            gQwBATAfBgNVHSMEGDAWgBTD+UUDvsj5CzxFNfPrcuzn6OuUmzAdBgNVHQ4EFgQU
+            7vNz5mM0I6JgWqm+556364tWmW8wCQYDVR0TBAIwADAKBggqhkjOPQQDAgNoADBl
+            AjBwybhS35Z4KFf1pt20LC9/CyxsDya3W/NbMn+bZ0RNNnOPABMv/Z3Xj7w086v4
+            PFcCMQDJVzG8VALwsAvO3JmKPy2LguNq0+pylaihUYGEg6rxxg5WyCXfnpZu0c+i
+            N5YHEvI=
+            """,
+            options: .ignoreUnknownCharacters)!
+        )
+
+        XCTAssertNoThrow(try Certificate(derEncoded: cert))
+    }
+
+    func testUsingWeirdHashFunctions() async throws {
+        let now = Date()
+        let issuerKey = P384.Signing.PrivateKey()
+        let issuerName = try DistinguishedName {
+            CommonName("Issuer")
+        }
+        let issuer = try Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(issuerKey.publicKey),
+            notValidBefore: now,
+            notValidAfter: now + 100,
+            issuer: issuerName,
+            subject: issuerName,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: try Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+                )
+            },
+            issuerPrivateKey: .init(issuerKey)
+        )
+
+        let leafKey = P384.Signing.PrivateKey()
+        let leafName = try DistinguishedName {
+            CommonName("Leaf")
+        }
+        let leaf = try Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(leafKey.publicKey),
+            notValidBefore: now,
+            notValidAfter: now + 50,
+            issuer: issuerName,
+            subject: leafName,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: try Certificate.Extensions {
+                Critical(
+                    BasicConstraints.notCertificateAuthority
+                )
+            },
+            issuerPrivateKey: .init(issuerKey)
+        )
+
+        // We should be able to serialize and deserialize this, and have it remain equal.
+        var serializer = DER.Serializer()
+        try serializer.serialize(leaf)
+        let parsed = try Certificate(derEncoded: serializer.serializedBytes)
+        XCTAssertEqual(parsed, leaf)
+
+        // And we should be able to validate it.
+        let roots = CertificateStore([issuer])
+        var verifier = Verifier(rootCertificates: roots, policy: PolicySet(policies: [RFC5280Policy(validationTime: now + 1)]))
+        let result = await verifier.validate(leafCertificate: parsed, intermediates: CertificateStore())
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Failed to validate cert")
+            return
+        }
+
+        XCTAssertEqual(chain, [parsed, issuer])
+    }
 }

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -48,7 +48,7 @@ final class SignatureTests: XCTestCase {
             signatureAlgorithm: .ecdsaWithSHA384,
             signatureBytes: ASN1BitString(bytes: signatureBytes[...])
         )
-        guard case .p384 = signature.backing else {
+        guard case .ecdsa(let sig) = signature.backing, P384.Signing.ECDSASignature(sig) != nil else {
             XCTFail("Invalid signature decode")
             return
         }


### PR DESCRIPTION
This patch modifies the ECDSA signature representation internally to avoid eagerly creating the Crypto type. This is necessary because we can't actually know what key created the signature when we parse it. As a result we have to defer actually doing that until we actually get a key type, at which point we can create the underlying key type.

This is a bit less efficient for us overall, but it solves a long-tail problem in the WebPKI that is more likely to increase in frequency over time.