### PR TITLE
Add SPI support for disabling expiry checking in RFC5280Policy.

### DIFF
--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -36,7 +36,7 @@ public struct RFC5280Policy: VerifierPolicy {
     ]
 
     @usableFromInline
-    let expiryPolicy: ExpiryPolicy
+    let expiryPolicy: ExpiryPolicy?
 
     @usableFromInline
     let basicConstraintsPolicy: BasicConstraintsPolicy
@@ -51,9 +51,20 @@ public struct RFC5280Policy: VerifierPolicy {
         self.nameConstraintsPolicy = NameConstraintsPolicy()
     }
 
+    private init() {
+        self.expiryPolicy = nil
+        self.basicConstraintsPolicy = BasicConstraintsPolicy()
+        self.nameConstraintsPolicy = NameConstraintsPolicy()
+    }
+
+    @_spi(DisableValidityCheck)
+    public static func withValidityCheckDisabled() -> RFC5280Policy {
+        return RFC5280Policy()
+    }
+
     @inlinable
     public func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
-        if case .failsToMeetPolicy(let reason) = self.expiryPolicy.chainMeetsPolicyRequirements(chain: chain) {
+        if let expiryPolicy = self.expiryPolicy, case .failsToMeetPolicy(let reason) = expiryPolicy.chainMeetsPolicyRequirements(chain: chain) {
             return .failsToMeetPolicy(reason: reason)
         }
 


### PR DESCRIPTION
In general, disabling expiry checking is not a useful thing to do: it weakens security posture for no reason. In some testing use-cases or unusual product cases, however, it's valuable to do this. This patch adds support for ripping out expiry checking.