### PR TITLE
Add support for using SecureEnclave.P256

### DIFF
--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -154,6 +154,28 @@ extension P256.Signing.PrivateKey {
     }
 }
 
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+extension SecureEnclave.P256.Signing.PrivateKey {
+    @inlinable
+    func signature<Bytes: DataProtocol>(for bytes: Bytes, digestAlgorithm: AlgorithmIdentifier) throws -> Certificate.Signature {
+        let signature: P256.Signing.ECDSASignature
+
+        switch try Digest.computeDigest(for: bytes, using: digestAlgorithm) {
+        case .insecureSHA1(let sha1):
+            signature = try self.signature(for: sha1)
+        case .sha256(let sha256):
+            signature = try self.signature(for: sha256)
+        case .sha384(let sha384):
+            signature = try self.signature(for: sha384)
+        case .sha512(let sha512):
+            signature = try self.signature(for: sha512)
+        }
+
+        return Certificate.Signature(backing: .ecdsa(.init(signature)))
+    }
+}
+#endif
+
 extension P384.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(for bytes: Bytes, digestAlgorithm: AlgorithmIdentifier) throws -> Certificate.Signature {

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -27,6 +27,9 @@ final class SignatureTests: XCTestCase {
     static let p384Key = P384.Signing.PrivateKey()
     static let p521Key = P521.Signing.PrivateKey()
     static let rsaKey = try! _RSA.Signing.PrivateKey(keySize: .bits2048)
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    static let secureEnclaveP256 = try! SecureEnclave.P256.Signing.PrivateKey()
+    #endif
 
     func testP384Signature() throws {
         // This is the P384 signature over LetsEncrypt Intermediate E1.
@@ -201,4 +204,34 @@ final class SignatureTests: XCTestCase {
     func testHashFunctionMismatch_rsa_sha512WithRSAEncryption() throws {
         try self.hashFunctionMismatchTest(privateKey: .init(Self.rsaKey), signatureAlgorithm: .sha512WithRSAEncryption, validCombination: true)
     }
+    
+    #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+    func testHashFunctionMismatch_secureEnclaveP256_ecdsaWithSHA256() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .ecdsaWithSHA256, validCombination: true)
+    }
+    
+    func testHashFunctionMismatch_secureEnclaveP256_ecdsaWithSHA384() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .ecdsaWithSHA384, validCombination: true)
+    }
+
+    func testHashFunctionMismatch_secureEnclaveP256_ecdsaWithSHA512() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .ecdsaWithSHA512, validCombination: true)
+    }
+
+    func testHashFunctionMismatch_secureEnclaveP256_sha1WithRSAEncryption() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .sha1WithRSAEncryption, validCombination: false)
+    }
+
+    func testHashFunctionMismatch_secureEnclaveP256_sha256WithRSAEncryption() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .sha256WithRSAEncryption, validCombination: false)
+    }
+
+    func testHashFunctionMismatch_secureEnclaveP256_sha384WithRSAEncryption() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .sha384WithRSAEncryption, validCombination: false)
+    }
+
+    func testHashFunctionMismatch_secureEnclaveP256_sha512WithRSAEncryption() throws {
+        try self.hashFunctionMismatchTest(privateKey: .init(Self.secureEnclaveP256), signatureAlgorithm: .sha512WithRSAEncryption, validCombination: false)
+    }
+    #endif
 }


### PR DESCRIPTION
In some PKI applications private keys should be kept in the most secure manner possible.  The SecureEnclave provides the most secure repository and signing capabilities on Apple hardware. These changes allow applications to use SecureEnclave managed P256 private keys which can be referenced in a keychain while the cryptographic material and signing operations never leave the SecureEnclave.

The following key initializer is added to the api. Certificate.PrivateKey(SecureEnclave.P256.Signing.PrivateKey())

Issue: https://github.com/apple/swift-certificates/issues/51