### PR TITLE
Add support for unwrapping public keys.

### DIFF
--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -223,3 +223,67 @@ extension _RSA.Signing.Padding {
         }
     }
 }
+
+extension P256.Signing.PublicKey {
+    /// Create a P256 Public Key from a given ``Certificate/PublicKey-swift.struct``.
+    ///
+    /// Fails if the key is not a P256 key.
+    ///
+    /// - parameters:
+    ///     - key: The key to unwrap.
+    public init?(_ key: Certificate.PublicKey) {
+        if case .p256(let inner) = key.backing {
+            self = inner
+        } else {
+            return nil
+        }
+    }
+}
+
+extension P384.Signing.PublicKey {
+    /// Create a P384 Public Key from a given ``Certificate/PublicKey-swift.struct``.
+    ///
+    /// Fails if the key is not a P384 key.
+    ///
+    /// - parameters:
+    ///     - key: The key to unwrap.
+    public init?(_ key: Certificate.PublicKey) {
+        if case .p384(let inner) = key.backing {
+            self = inner
+        } else {
+            return nil
+        }
+    }
+}
+
+extension P521.Signing.PublicKey {
+    /// Create a P521 Public Key from a given ``Certificate/PublicKey-swift.struct``.
+    ///
+    /// Fails if the key is not a P521 key.
+    ///
+    /// - parameters:
+    ///     - key: The key to unwrap.
+    public init?(_ key: Certificate.PublicKey) {
+        if case .p521(let inner) = key.backing {
+            self = inner
+        } else {
+            return nil
+        }
+    }
+}
+
+extension _RSA.Signing.PublicKey {
+    /// Create an RSA Public Key from a given ``Certificate/PublicKey-swift.struct``.
+    ///
+    /// Fails if the key is not an RSA key.
+    ///
+    /// - parameters:
+    ///     - key: The key to unwrap.
+    public init?(_ key: Certificate.PublicKey) {
+        if case .rsa(let inner) = key.backing {
+            self = inner
+        } else {
+            return nil
+        }
+    }
+}

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -13,6 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import Crypto
+import _CryptoExtras
 import SwiftASN1
 @testable import X509
 
@@ -294,5 +296,67 @@ final class CertificateTests: XCTestCase {
         
         var rngWithTrailingZero = StaticNumberGenerator(numbers: [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 0])
         XCTAssertEqual(Certificate.SerialNumber(generator: &rngWithTrailingZero).bytes, [1, 2, 3, 4, 5, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 0])
+    }
+
+    func testRoundTrippingKeys() throws {
+        let p256 = P256.Signing.PrivateKey()
+        let p384 = P384.Signing.PrivateKey()
+        let p521 = P521.Signing.PrivateKey()
+        let rsa = try _RSA.Signing.PrivateKey(keySize: .bits2048)
+
+        XCTAssertEqual(
+            p256.publicKey.rawRepresentation,
+            P256.Signing.PublicKey(Certificate.PublicKey(p256.publicKey))?.rawRepresentation
+        )
+        XCTAssertEqual(
+            p384.publicKey.rawRepresentation,
+            P384.Signing.PublicKey(Certificate.PublicKey(p384.publicKey))?.rawRepresentation
+        )
+        XCTAssertEqual(
+            p521.publicKey.rawRepresentation,
+            P521.Signing.PublicKey(Certificate.PublicKey(p521.publicKey))?.rawRepresentation
+        )
+        XCTAssertEqual(
+            rsa.publicKey.derRepresentation,
+            _RSA.Signing.PublicKey(Certificate.PublicKey(rsa.publicKey))?.derRepresentation
+        )
+
+        // Don't project to other things
+        XCTAssertNil(
+            P256.Signing.PublicKey(Certificate.PublicKey(p384.publicKey))
+        )
+        XCTAssertNil(
+            P256.Signing.PublicKey(Certificate.PublicKey(p521.publicKey))
+        )
+        XCTAssertNil(
+            P256.Signing.PublicKey(Certificate.PublicKey(rsa.publicKey))
+        )
+        XCTAssertNil(
+            P384.Signing.PublicKey(Certificate.PublicKey(p256.publicKey))
+        )
+        XCTAssertNil(
+            P384.Signing.PublicKey(Certificate.PublicKey(p521.publicKey))
+        )
+        XCTAssertNil(
+            P384.Signing.PublicKey(Certificate.PublicKey(rsa.publicKey))
+        )
+        XCTAssertNil(
+            P521.Signing.PublicKey(Certificate.PublicKey(p256.publicKey))
+        )
+        XCTAssertNil(
+            P521.Signing.PublicKey(Certificate.PublicKey(p384.publicKey))
+        )
+        XCTAssertNil(
+            P521.Signing.PublicKey(Certificate.PublicKey(rsa.publicKey))
+        )
+        XCTAssertNil(
+            _RSA.Signing.PublicKey(Certificate.PublicKey(p256.publicKey))
+        )
+        XCTAssertNil(
+            _RSA.Signing.PublicKey(Certificate.PublicKey(p384.publicKey))
+        )
+        XCTAssertNil(
+            _RSA.Signing.PublicKey(Certificate.PublicKey(p521.publicKey))
+        )
     }
 }


### PR DESCRIPTION
In many circumstances it may be useful to extract the underlying public key from a Certificate.PublicKey. This patch adds support for optionally unwrapping the key into the various base types.