### PR TITLE
Expose a CMSSignature type

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(X509
   "CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift"
   "CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift"
   "CryptographicMessageSyntax/CMSOperations.swift"
+  "CryptographicMessageSyntax/CMSSignature.swift"
   "CryptographicMessageSyntax/CMSSignedData.swift"
   "CryptographicMessageSyntax/CMSSignerIdentifier.swift"
   "CryptographicMessageSyntax/CMSSignerInfo.swift"

--- a/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
@@ -44,7 +44,7 @@ extension ASN1ObjectIdentifier {
 /// ContentType ::= OBJECT IDENTIFIER
 /// ```
 @usableFromInline
-struct CMSContentInfo: DERImplicitlyTaggable, Hashable {
+struct CMSContentInfo: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSEncapsulatedContentInfo.swift
@@ -22,7 +22,7 @@ import SwiftASN1
 /// ContentType ::= OBJECT IDENTIFIER
 /// ```
 @usableFromInline
-struct CMSEncapsulatedContentInfo: DERImplicitlyTaggable, Hashable {
+struct CMSEncapsulatedContentInfo: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
@@ -23,7 +23,7 @@ import SwiftASN1
 /// The definition of `Name` is taken from X.501 [X.501-88], and the
 /// definition of `CertificateSerialNumber` is taken from X.509 [X.509-97].
 @usableFromInline
-struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable {
+struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -168,6 +168,7 @@ public enum CMS {
     @_spi(CMS)
     public enum Error: Swift.Error {
         case incorrectCMSVersionUsed
+        case unexpectedCMSType
     }
 
     @_spi(CMS)

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftASN1
+
+/// A representation of a CMS signature over some data.
+///
+/// This type hides the specifics of how CMS represents data, instead offering a limited
+/// view over a CMS signed-data payload. It also abstracts the specific ASN.1 layout of the
+/// signature.
+@_spi(CMS)
+public struct CMSSignature: Sendable, Hashable {
+    @usableFromInline
+    let base: CMSSignedData
+
+    /// Returns the certificates associated with the signers
+    @inlinable
+    public var signers: [Signer] {
+        get throws {
+            try self.base.signerInfos.compactMap { signerInfo in
+                try self.base.certificates?.certificate(signerInfo: signerInfo).map { Signer(certificate: $0) }
+            }
+        }
+    }
+
+    /// The certificates in the signature.
+    @inlinable
+    public var certificates: [Certificate] {
+        self.base.certificates ?? []
+    }
+}
+
+extension CMSSignature: DERImplicitlyTaggable {
+    @inlinable
+    public static var defaultIdentifier: ASN1Identifier {
+        CMSContentInfo.defaultIdentifier
+    }
+
+    @inlinable
+    public init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
+        guard let base = try CMSContentInfo(derEncoded: rootNode, withIdentifier: identifier).signedData, base.version == .v1 else {
+            throw CMS.Error.unexpectedCMSType
+        }
+
+        self.base = base
+    }
+
+    @inlinable
+    public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
+        try CMSContentInfo(self.base).serialize(into: &coder, withIdentifier: identifier)
+    }
+}
+
+extension CMSSignature {
+    /// One of the "signers" that produced a given CMS block.
+    ///
+    /// Note that the signer has not been validated, so it is possible that the signer did not actually
+    /// sign the block in question.
+    @_spi(CMS)
+    public struct Signer: Sendable, Hashable {
+        public let certificate: Certificate
+
+        @inlinable
+        init(certificate: Certificate) {
+            self.certificate = certificate
+        }
+    }
+}

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
@@ -42,7 +42,7 @@ import SwiftASN1
 /// ```
 /// - Note: At the moment we don't support `crls` (`RevocationInfoChoices`)
 @usableFromInline
-struct CMSSignedData: DERImplicitlyTaggable, Hashable {
+struct CMSSignedData: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
@@ -21,7 +21,7 @@ import SwiftASN1
 ///   subjectKeyIdentifier [0] SubjectKeyIdentifier }
 ///  ```
 @usableFromInline
-enum CMSSignerIdentifier: DERParseable, DERSerializable, Hashable {
+enum CMSSignerIdentifier: DERParseable, DERSerializable, Hashable, Sendable {
 
     @usableFromInline
     static let skiIdentifier = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -34,7 +34,7 @@ import SwiftASN1
 /// then the `version` MUST be 3.
 /// - Note: At the moment we neither support `signedAttrs` (`SignedAttributes`) nor `unsignedAttrs` (`UnsignedAttributes`)
 @usableFromInline
-struct CMSSignerInfo: DERImplicitlyTaggable, Hashable {
+struct CMSSignerInfo: DERImplicitlyTaggable, Hashable, Sendable {
     @usableFromInline
     enum Error: Swift.Error {
         case versionAndSignerIdentifierMismatch(String)

--- a/Sources/X509/CryptographicMessageSyntax/CMSVersion.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSVersion.swift
@@ -20,7 +20,7 @@ import SwiftASN1
 ///                 { v0(0), v1(1), v2(2), v3(3), v4(4), v5(5) }
 /// ```
 @usableFromInline
-struct CMSVersion: RawRepresentable, Hashable {
+struct CMSVersion: RawRepresentable, Hashable, Sendable {
     @usableFromInline
     var rawValue: Int
 


### PR DESCRIPTION
There are some use-cases where interrogating the structure of a CMS signature is necessary. This patch adds an SPI for looking at a CMS signature.

As with the rest of our CMS operations, we're not willing to commit to an API shape yet, so this patch doesn't provide one. Instead, users need to opt-in to using the unstable API.