### PR TITLE
Exclude Secure Enclave related code from CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,9 @@ if(BUILD_SHARED_LIBS)
   set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 endif()
 
+## Uncomment line below to include code that provides Secure Enclave support
+##add_compile_definitions(INCLUDE_SECURE_ENCLAVE_SUPPORT)
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(dispatch CONFIG)
   find_package(Foundation CONFIG)

--- a/Package.swift
+++ b/Package.swift
@@ -16,6 +16,11 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
+var swiftSettings: [SwiftSetting] = []
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+swiftSettings.append(.define("INCLUDE_SECURE_ENCLAVE_SUPPORT"))
+#endif
+
 let package = Package(
     name: "swift-certificates",
     platforms: [
@@ -39,7 +44,8 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt",
-            ]),
+            ],
+            swiftSettings: swiftSettings),
         .testTarget(
             name: "X509Tests",
             dependencies: [

--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2022-2023 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -63,7 +63,7 @@ extension Certificate {
             self.backing = .rsa(rsa)
         }
         
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if INCLUDE_SECURE_ENCLAVE_SUPPORT
         /// Construct a private key wrapping a SecureEnclave.P256 private key.
         /// - Parameter secureEnclaveP256: The SecureEnclave.P256 private key to wrap.
         @inlinable
@@ -87,7 +87,7 @@ extension Certificate {
             case .rsa(let rsa):
                 let padding = try _RSA.Signing.Padding(forSignatureAlgorithm: signatureAlgorithm)
                 return try rsa.signature(for: bytes, digestAlgorithm: digestAlgorithm, padding: padding)
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
             case .secureEnclaveP256(let secureEnclaveP256):
                 return try secureEnclaveP256.signature(for: bytes, digestAlgorithm: digestAlgorithm)
             #endif
@@ -107,7 +107,7 @@ extension Certificate {
                 return PublicKey(p521.publicKey)
             case .rsa(let rsa):
                 return PublicKey(rsa.publicKey)
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
             case .secureEnclaveP256(let secureEnclaveP256):
                 return PublicKey(secureEnclaveP256.publicKey)
             #endif
@@ -125,7 +125,7 @@ extension Certificate {
                 if !algorithm.isRSA {
                     throw CertificateError.unsupportedSignatureAlgorithm(reason: "Cannot use \(algorithm) with RSA key \(self)")
                 }
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
             case .secureEnclaveP256:
                 if !algorithm.isECDSA {
                     throw CertificateError.unsupportedSignatureAlgorithm(reason: "Cannot use \(algorithm) with ECDSA key \(self)")
@@ -154,7 +154,7 @@ extension Certificate.PrivateKey {
         case p384(Crypto.P384.Signing.PrivateKey)
         case p521(Crypto.P521.Signing.PrivateKey)
         case rsa(_CryptoExtras._RSA.Signing.PrivateKey)
-        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        #if INCLUDE_SECURE_ENCLAVE_SUPPORT
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
         #endif
 
@@ -169,7 +169,7 @@ extension Certificate.PrivateKey {
                 return l.rawRepresentation == r.rawRepresentation
             case (.rsa(let l), .rsa(let r)):
                 return l.derRepresentation == r.derRepresentation
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
             case (.secureEnclaveP256(let l), .secureEnclaveP256(let r)):
                 return l.dataRepresentation == r.dataRepresentation
             #endif
@@ -193,7 +193,7 @@ extension Certificate.PrivateKey {
             case .rsa(let digest):
                 hasher.combine(3)
                 hasher.combine(digest.derRepresentation)
-            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
             case .secureEnclaveP256(let digest):
                 hasher.combine(4)
                 hasher.combine(digest.dataRepresentation)

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -154,7 +154,7 @@ extension P256.Signing.PrivateKey {
     }
 }
 
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#if INCLUDE_SECURE_ENCLAVE_SUPPORT
 extension SecureEnclave.P256.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(for bytes: Bytes, digestAlgorithm: AlgorithmIdentifier) throws -> Certificate.Signature {


### PR DESCRIPTION
Motivation:
macOS CMake build is failing with error:

```
/Users/ec2-user/jenkins/workspace/swift-package-manager-PR-macos-smoke-test/branch-main/swift-certificates/Sources/X509/CertificatePrivateKey.swift:158:32: error: cannot find type 'SecureEnclave' in scope
        case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
                               ^~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

https://ci.swift.org/job/swift-package-manager-PR-macos-smoke-test/2207/console

Modifications:
Introduce compiler directive `INCLUDE_SECURE_ENCLAVE_SUPPORT` to control when to include Secure Enclave related code. It is set in SwiftPM build (`Package.swift`) but not CMake.