### PR TITLE
Proper fix for 'SecureEnclave' issue in cmake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,9 +37,6 @@ if(BUILD_SHARED_LIBS)
   set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 endif()
 
-## Uncomment line below to include code that provides Secure Enclave support
-##add_compile_definitions(INCLUDE_SECURE_ENCLAVE_SUPPORT)
-
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(dispatch CONFIG)
   find_package(Foundation CONFIG)

--- a/Package.swift
+++ b/Package.swift
@@ -16,11 +16,6 @@
 import PackageDescription
 import class Foundation.ProcessInfo
 
-var swiftSettings: [SwiftSetting] = []
-#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
-swiftSettings.append(.define("INCLUDE_SECURE_ENCLAVE_SUPPORT"))
-#endif
-
 let package = Package(
     name: "swift-certificates",
     platforms: [
@@ -44,8 +39,7 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt",
-            ],
-            swiftSettings: swiftSettings),
+            ]),
         .testTarget(
             name: "X509Tests",
             dependencies: [
@@ -67,7 +61,7 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.4.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.7.0")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ]

--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2022-2023 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -63,7 +63,7 @@ extension Certificate {
             self.backing = .rsa(rsa)
         }
         
-        #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         /// Construct a private key wrapping a SecureEnclave.P256 private key.
         /// - Parameter secureEnclaveP256: The SecureEnclave.P256 private key to wrap.
         @inlinable
@@ -87,7 +87,7 @@ extension Certificate {
             case .rsa(let rsa):
                 let padding = try _RSA.Signing.Padding(forSignatureAlgorithm: signatureAlgorithm)
                 return try rsa.signature(for: bytes, digestAlgorithm: digestAlgorithm, padding: padding)
-            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             case .secureEnclaveP256(let secureEnclaveP256):
                 return try secureEnclaveP256.signature(for: bytes, digestAlgorithm: digestAlgorithm)
             #endif
@@ -107,7 +107,7 @@ extension Certificate {
                 return PublicKey(p521.publicKey)
             case .rsa(let rsa):
                 return PublicKey(rsa.publicKey)
-            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             case .secureEnclaveP256(let secureEnclaveP256):
                 return PublicKey(secureEnclaveP256.publicKey)
             #endif
@@ -125,7 +125,7 @@ extension Certificate {
                 if !algorithm.isRSA {
                     throw CertificateError.unsupportedSignatureAlgorithm(reason: "Cannot use \(algorithm) with RSA key \(self)")
                 }
-            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             case .secureEnclaveP256:
                 if !algorithm.isECDSA {
                     throw CertificateError.unsupportedSignatureAlgorithm(reason: "Cannot use \(algorithm) with ECDSA key \(self)")
@@ -154,7 +154,7 @@ extension Certificate.PrivateKey {
         case p384(Crypto.P384.Signing.PrivateKey)
         case p521(Crypto.P521.Signing.PrivateKey)
         case rsa(_CryptoExtras._RSA.Signing.PrivateKey)
-        #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
         case secureEnclaveP256(SecureEnclave.P256.Signing.PrivateKey)
         #endif
 
@@ -169,7 +169,7 @@ extension Certificate.PrivateKey {
                 return l.rawRepresentation == r.rawRepresentation
             case (.rsa(let l), .rsa(let r)):
                 return l.derRepresentation == r.derRepresentation
-            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             case (.secureEnclaveP256(let l), .secureEnclaveP256(let r)):
                 return l.dataRepresentation == r.dataRepresentation
             #endif
@@ -193,7 +193,7 @@ extension Certificate.PrivateKey {
             case .rsa(let digest):
                 hasher.combine(3)
                 hasher.combine(digest.derRepresentation)
-            #if INCLUDE_SECURE_ENCLAVE_SUPPORT
+            #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
             case .secureEnclaveP256(let digest):
                 hasher.combine(4)
                 hasher.combine(digest.dataRepresentation)

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -154,7 +154,7 @@ extension P256.Signing.PrivateKey {
     }
 }
 
-#if INCLUDE_SECURE_ENCLAVE_SUPPORT
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
 extension SecureEnclave.P256.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(for bytes: Bytes, digestAlgorithm: AlgorithmIdentifier) throws -> Certificate.Signature {


### PR DESCRIPTION
Motivation:
https://github.com/apple/swift-certificates/pull/67 introduced a temporary workaround to unblock cmake build on macOS, but we have a proper fix now (https://github.com/apple/swift-crypto/pull/177).

Modifications:
- Revert https://github.com/apple/swift-certificates/pull/67
- Take new version of `swift-crypto` containing https://github.com/apple/swift-crypto/pull/177