### PR TITLE
Clean up the upToNextMinor

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To use swift-certificates, add the following dependency to your Package.swift:
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/apple/swift-certificates.git", upToNextMinor(from: "0.1.0"))
+    .package(url: "https://github.com/apple/swift-certificates.git", upToNextMinor(from: "0.4.0"))
 ]
 ```
 


### PR DESCRIPTION
Minor cleanup in the `upToNextMinor` code in the README.