### PR TITLE
X509: make the code more portable

### DIFF
--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -12,8 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CoreFoundation
 import Foundation
+#if os(Windows)
+import WinSDK
+#elseif os(Linux) || os(Android)
+import Glibc
+#elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
+import Darwin
+#endif
 
 extension NameConstraintsPolicy {
     /// Validates that a URI name matches a name constraint.
@@ -58,14 +64,22 @@ extension NameConstraintsPolicy {
 extension String {
     @inlinable
     var isIPAddress: Bool {
+#if os(Windows)
+        var v4: IN_ADDR = IN_ADDR()
+        var v6: IN6_ADDR = IN6_ADDR()
+            return self.withCString(encodedAs: UTF16.self) {
+                return InetPtonW(AF_INET, $0, &v4) == 1 ||
+                       InetPtonW(AF_INET6, $0, &v6) == 1
+            }
+#else
         // We need some scratch space to let inet_pton write into.
         var ipv4Addr = in_addr()
         var ipv6Addr = in6_addr()
-
         return self.withCString { ptr in
             return inet_pton(AF_INET, ptr, &ipv4Addr) == 1 ||
                    inet_pton(AF_INET6, ptr, &ipv6Addr) == 1
         }
+#endif
     }
 }
 

--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -17,6 +17,7 @@ import Foundation
 import WinSDK
 #elseif os(Linux) || os(Android)
 import Glibc
+import CoreFoundation
 #elseif os(iOS) || os(macOS) || os(tvOS) || os(watchOS)
 import Darwin
 #endif

--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -67,10 +67,10 @@ extension String {
 #if os(Windows)
         var v4: IN_ADDR = IN_ADDR()
         var v6: IN6_ADDR = IN6_ADDR()
-            return self.withCString(encodedAs: UTF16.self) {
-                return InetPtonW(AF_INET, $0, &v4) == 1 ||
-                       InetPtonW(AF_INET6, $0, &v6) == 1
-            }
+        return self.withCString(encodedAs: UTF16.self) {
+            return InetPtonW(AF_INET, $0, &v4) == 1 ||
+                   InetPtonW(AF_INET6, $0, &v6) == 1
+        }
 #else
         // We need some scratch space to let inet_pton write into.
         var ipv4Addr = in_addr()


### PR DESCRIPTION
`CoreFoundation` is not available on all platforms.  It never was meant to be available on Linux, but was accidentally pushed into the release and is now stuck.  Windows intentionally did not make this module visible.  With the future work with the Foundation rewrite `CoreFoundation` will disappear in more locations.

Windows does not support `inet_pton` except unless the string is explicitly ANSI and not UTF-8.  We must use the proper spelling of `InetPtonW` which takes a UTF-16 string.

The import of `CoreFoundation` was more for the dependency on the C library as a side-effect.  On Windows, the networking functions are provided by a separate user space library rather than the C library. This is now highlighted in the imports.