### PR TITLE
Fixed typo

### DIFF
--- a/Sources/X509/Docs.docc/Examining Certificates.md
+++ b/Sources/X509/Docs.docc/Examining Certificates.md
@@ -11,7 +11,7 @@ X.509 certificate.
 ## Parsing
 
 Certificates are commonly provided in two formats: PEM and DER. The two formats are closely
-related. PEM stands for "Private Enhanced Mail", and a PEM certificate commonly looks like
+related. PEM stands for "Privacy Enhanced Mail", and a PEM certificate commonly looks like
 this:
 
 ```


### PR DESCRIPTION
Fixes typo in the expansion of PEM.

Motivation:

Correcting the documentation.

Modifications:

Changed the expansion of PEM from "Private Enhanced Mail" to the correct "Privacy Enhanced Mail"

Result:

Documentation text corrected.