### PR TITLE
Gracefully fail `Extension` serialization

### DIFF
--- a/Sources/X509/Extensions.swift
+++ b/Sources/X509/Extensions.swift
@@ -123,8 +123,8 @@ extension Certificate {
         ///
         /// - Parameter builder: The ``ExtensionsBuilder`` DSL.
         @inlinable
-        public init(@ExtensionsBuilder builder: () throws -> Certificate.Extensions) throws {
-            self = try builder()
+        public init(@ExtensionsBuilder builder: () throws -> Result<Certificate.Extensions, any Error>) throws {
+            self = try builder().get()
         }
     }
 }

--- a/Sources/X509/ExtensionsBuilder.swift
+++ b/Sources/X509/ExtensionsBuilder.swift
@@ -41,39 +41,66 @@
 @resultBuilder
 public struct ExtensionsBuilder {
     @inlinable
-    public static func buildExpression<Extension: CertificateExtensionConvertible>(_ expression: Extension) -> Certificate.Extensions {
-        // TODO: we really need a way to avoid having this be try!.
-        try! Certificate.Extensions([expression.makeCertificateExtension()])
+    public static func buildExpression<Extension: CertificateExtensionConvertible>(_ expression: Extension) -> Result<Certificate.Extensions, any Error> {
+        Result {
+            try Certificate.Extensions([expression.makeCertificateExtension()])
+        }
+    }
+    
+    @inlinable
+    public static func buildExpression(_ expression: Certificate.Extensions) -> Result<Certificate.Extensions, any Error> {
+        .success(expression)
+    }
+    
+    @inlinable
+    public static func buildExpression() -> Result<Certificate.Extensions, any Error> {
+        .success(Certificate.Extensions())
+    }
+    
+    @inlinable
+    public static func buildBlock() -> Result<Certificate.Extensions, any Error> {
+        .success(Certificate.Extensions())
     }
 
     @inlinable
-    public static func buildBlock(_ components: Certificate.Extensions...) -> Certificate.Extensions {
-        Certificate.Extensions(components.lazy.flatMap { $0 })
+    public static func buildBlock(_ components: Result<Certificate.Extensions, any Error>...) -> Result<Certificate.Extensions, any Error> {
+        Result {
+            Certificate.Extensions(try components.lazy.flatMap { try $0.get() })
+        }
     }
 
     @inlinable
-    public static func buildOptional(_ component: Certificate.Extensions?) -> Certificate.Extensions {
-        component ?? Certificate.Extensions([])
+    public static func buildOptional(_ component: Result<Certificate.Extensions, any Error>?) -> Result<Certificate.Extensions, any Error> {
+        component ?? .success(Certificate.Extensions([]))
     }
 
     @inlinable
-    public static func buildEither(first component: Certificate.Extensions) -> Certificate.Extensions {
+    public static func buildEither(first component: Result<Certificate.Extensions, any Error>) -> Result<Certificate.Extensions, any Error> {
         component
     }
 
     @inlinable
-    public static func buildEither(second component: Certificate.Extensions) -> Certificate.Extensions {
+    public static func buildEither(second component: Result<Certificate.Extensions, any Error>) -> Result<Certificate.Extensions, any Error> {
         component
     }
 
     @inlinable
-    public static func buildArray(_ components: [Certificate.Extensions]) -> Certificate.Extensions {
-        Certificate.Extensions(components.lazy.flatMap { $0 })
+    public static func buildArray(_ components: [Result<Certificate.Extensions, any Error>]) -> Result<Certificate.Extensions, any Error> {
+        Result {
+            Certificate.Extensions(try components.lazy.flatMap { try $0.get() })
+        }
     }
 
     @inlinable
-    public static func buildLimitedAvailability(_ component: Certificate.Extensions) -> Certificate.Extensions {
+    public static func buildLimitedAvailability(_ component: Result<Certificate.Extensions, any Error>) -> Result<Certificate.Extensions, any Error> {
         component
+    }
+}
+
+
+func foo() -> Certificate.Extensions {
+    try! .init {
+        
     }
 }
 

--- a/Sources/X509/ExtensionsBuilder.swift
+++ b/Sources/X509/ExtensionsBuilder.swift
@@ -97,13 +97,6 @@ public struct ExtensionsBuilder {
     }
 }
 
-
-func foo() -> Certificate.Extensions {
-    try! .init {
-        
-    }
-}
-
 /// Conforming types are capable of being erased into ``Certificate/Extension`` values.
 ///
 /// Note that for most extension types, the returned ``Certificate/Extension`` should have its

--- a/Tests/X509Tests/ExtensionBuilderTests.swift
+++ b/Tests/X509Tests/ExtensionBuilderTests.swift
@@ -68,4 +68,85 @@ final class ExtensionBuilderTests: XCTestCase {
 
         XCTAssertEqual(extensions, expectedExtensions)
     }
+    
+    func testThrowingExtension() throws {
+        struct MyError: Error {}
+        struct MyThrowingExtension: CertificateExtensionConvertible {
+            func makeCertificateExtension() throws -> Certificate.Extension {
+                throw MyError()
+            }
+        }
+        
+        let `true` = true
+        let `false` = false
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            MyThrowingExtension()
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            MyThrowingExtension()
+            MyThrowingExtension()
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            for _ in 0..<3 {
+                MyThrowingExtension()
+            }
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            Certificate.Extension(oid: [1], critical: false, value: [1])
+            MyThrowingExtension()
+        })
+        XCTAssertThrowsError(try Certificate.Extensions {
+            MyThrowingExtension()
+            Certificate.Extension(oid: [1], critical: false, value: [1])
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            if `true` {
+                MyThrowingExtension()
+            }
+        })
+        
+        XCTAssertNoThrow(try Certificate.Extensions {
+            if `false` {
+                MyThrowingExtension()
+            }
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            if `true` {
+                MyThrowingExtension()
+            } else {
+                Certificate.Extension(oid: [1], critical: false, value: [1])
+            }
+        })
+        
+        XCTAssertNoThrow(try Certificate.Extensions {
+            if `false` {
+                MyThrowingExtension()
+            } else {
+                Certificate.Extension(oid: [1], critical: false, value: [1])
+            }
+        })
+        
+        XCTAssertNoThrow(try Certificate.Extensions {
+            if `true` {
+                Certificate.Extension(oid: [1], critical: false, value: [1])
+            } else {
+                MyThrowingExtension()
+            }
+        })
+        
+        XCTAssertThrowsError(try Certificate.Extensions {
+            if `false` {
+                Certificate.Extension(oid: [1], critical: false, value: [1])
+            } else {
+                MyThrowingExtension()
+            }
+        })
+
+    }
 }

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -769,7 +769,7 @@ extension BasicOCSPResponse {
         responses: [OCSPSingleResponse],
         privateKey: P384.Signing.PrivateKey = OCSPVerifierPolicyTests.intermediatePrivateKey,
         certs: [Certificate]? = [],
-        @ExtensionsBuilder responseExtensions: () -> Certificate.Extensions = { .init() }
+        @ExtensionsBuilder responseExtensions: () throws -> Result<Certificate.Extensions, any Error> = { .success(Certificate.Extensions()) }
     ) throws -> Self {
         try .signed(
             responseData: .init(
@@ -777,7 +777,7 @@ extension BasicOCSPResponse {
                 responderID: responderID,
                 producedAt: producedAt,
                 responses: responses,
-                responseExtensions: responseExtensions()
+                responseExtensions: try responseExtensions().get()
             ),
             privateKey: privateKey,
             certs: certs


### PR DESCRIPTION
### Motivation
We currently crash if `Extension` serialization fails but we should throw an error instead.

### Changes
All `@resultBuilder` `build*` methods do not support throwing. We therefore need to delay throwing until the very end. The `@resultBuilder` final result type is now no longer `Certificate.Extensions` but `Result<Certificate.Extensions, any Error>` which allows us to forward the error. 

### Result
We throw the first serialization error instead of crashing. Note that we still serialize all `Extension`s but only preserve the error of the first failure.