### PR TITLE
Make expiry checking cheaper.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -64,7 +64,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
         .package(url: "https://github.com/apple/swift-crypto.git", from: "2.5.0"),
-        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.8.0")),
+        .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.9.1")),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ]
 } else {

--- a/Sources/X509/X509BaseTypes/Time.swift
+++ b/Sources/X509/X509BaseTypes/Time.swift
@@ -135,6 +135,35 @@ extension Date {
     }
 }
 
+extension GeneralizedTime {
+    @inlinable
+    init(_ date: Date) {
+        let components = gregorianCalendar.dateComponents(in: utcTimeZone, from: date)
+
+        // This cannot throw: Date always meets the requirements.
+        self = try! GeneralizedTime(
+            year: components.year!,
+            month: components.month!,
+            day: components.day!,
+            hours: components.hour!,
+            minutes: components.minute!,
+            seconds: components.second!,
+            fractionalSeconds: 0.0
+        )
+    }
+
+    @inlinable
+    init(_ time: Time) {
+        switch time {
+        case .generalTime(let t):
+            self = t
+        case .utcTime(let t):
+            // This can never throw, all valid UTCTimes are valid GeneralizedTimes
+            self = try! GeneralizedTime(year: t.year, month: t.month, day: t.day, hours: t.hours, minutes: t.minutes, seconds: t.seconds, fractionalSeconds: 0)
+        }
+    }
+}
+
 @usableFromInline
 let gregorianCalendar = Calendar(identifier: .gregorian)
 

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -339,12 +339,12 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 XCTAssertEqual(request.tbsRequest.requestList.count, 1)
                 let singleRequest = try XCTUnwrap(request.tbsRequest.requestList.first)
                 return .successful(try .signed(
-                    producedAt: try .init(validationTime),
+                    producedAt: .init(validationTime),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .good,
-                        thisUpdate: try .init(now - .days(1)),
-                        nextUpdate: try .init(now + .days(1))
+                        thisUpdate: .init(now - .days(1)),
+                        nextUpdate: .init(now + .days(1))
                     )]) {
                         nonce
                     }
@@ -366,12 +366,12 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 XCTAssertEqual(request.tbsRequest.requestList.count, 1)
                 let singleRequest = try XCTUnwrap(request.tbsRequest.requestList.first)
                 return .successful(try .signed(
-                    producedAt: try .init(validationTime),
+                    producedAt: .init(validationTime),
                     responses: [OCSPSingleResponse(
                     certID: singleRequest.certID,
                     certStatus: .good,
-                    thisUpdate: try .init(now - .days(1)),
-                    nextUpdate: try .init(now + .days(1))
+                    thisUpdate: .init(now - .days(1)),
+                    nextUpdate: .init(now + .days(1))
                     )]) {
                         OCSPNonce()
                     }
@@ -393,15 +393,15 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 XCTAssertEqual(request.tbsRequest.requestList.count, 1)
                 let singleRequest = try XCTUnwrap(request.tbsRequest.requestList.first)
                 return .successful(try .signed(
-                    producedAt: try .init(validationTime),
+                    producedAt: .init(validationTime),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .revoked(.init(
-                            revocationTime: try .init(now),
+                            revocationTime: .init(now),
                             revocationReason: .unspecified
                         )),
-                        thisUpdate: try .init(now - .days(1)),
-                        nextUpdate: try .init(now + .days(1))
+                        thisUpdate: .init(now - .days(1)),
+                        nextUpdate: .init(now + .days(1))
                     )]) {
                         nonce
                     }
@@ -424,12 +424,12 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 let singleRequest = try XCTUnwrap(request.tbsRequest.requestList.first)
                 return .successful(try .signed(
                     responderID: .byName(Self.invalidResponderIntermediate1.subject),
-                    producedAt: try .init(validationTime),
+                    producedAt: .init(validationTime),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .good,
-                        thisUpdate: try .init(now - .days(1)),
-                        nextUpdate: try .init(now + .days(1))
+                        thisUpdate: .init(now - .days(1)),
+                        nextUpdate: .init(now + .days(1))
                     )],
                     privateKey: Self.responderIntermediate1PrivateKey,
                     certs: [Self.invalidResponderIntermediate1]) {
@@ -456,12 +456,12 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 let responseData = OCSPResponseData(
                     version: .v1,
                     responderID: Self.responderId,
-                    producedAt: try .init(Date()),
+                    producedAt: .init(Date()),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .good,
-                        thisUpdate: try .init(now - .days(1)),
-                        nextUpdate: try .init(now + .days(1))
+                        thisUpdate: .init(now - .days(1)),
+                        nextUpdate: .init(now + .days(1))
                     )],
                     responseExtensions: try .init {
                         nonce
@@ -499,7 +499,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 let nonce = try XCTUnwrap(request.tbsRequest.requestExtensions?.ocspNonce)
                 XCTAssertEqual(request.tbsRequest.requestList.count, 1)
                 return .successful(try .signed(
-                    producedAt: try .init(validationTime),
+                    producedAt: .init(validationTime),
                     responses: [OCSPSingleResponse(
                         certID: .init(
                             hashAlgorithm: .init(algorithm: .sha1NoSign, parameters: nil),
@@ -508,8 +508,8 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                             serialNumber: .init()
                         ),
                         certStatus: .good,
-                        thisUpdate: try .init(now - .days(1)),
-                        nextUpdate: try .init(now + .days(1))
+                        thisUpdate: .init(now - .days(1)),
+                        nextUpdate: .init(now + .days(1))
                     )]) {
                         nonce
                     }
@@ -577,12 +577,12 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 XCTAssertEqual(request.tbsRequest.requestList.count, 1)
                 let singleRequest = try XCTUnwrap(request.tbsRequest.requestList.first)
                 return .successful(try .signed(
-                    producedAt: try .init(producedAt),
+                    producedAt: .init(producedAt),
                     responses: [OCSPSingleResponse(
                         certID: singleRequest.certID,
                         certStatus: .good,
-                        thisUpdate: try .init(thisUpdate),
-                        nextUpdate: try nextUpdate.map { try .init($0) }
+                        thisUpdate: .init(thisUpdate),
+                        nextUpdate: nextUpdate.map { .init($0) }
                     )]) {
                         nonce
                     }

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -726,22 +726,6 @@ final class OCSPVerifierPolicyTests: XCTestCase {
     }
 }
 
-extension GeneralizedTime {
-    init(_ date: Date) throws {
-        let components = gregorianCalendar.dateComponents(in: utcTimeZone, from: date)
-        try self.init(
-            year: components.year!,
-            month: components.month!,
-            day: components.day!,
-            hours: components.hour!,
-            minutes: components.minute!,
-            seconds: components.second!,
-            fractionalSeconds: 0.0
-        )
-    }
-}
-
-
 extension BasicOCSPResponse {
     static func signed(
         responseData: OCSPResponseData,

--- a/Tests/X509Tests/OCSPTests.swift
+++ b/Tests/X509Tests/OCSPTests.swift
@@ -522,7 +522,7 @@ final class OCSPTests: XCTestCase {
                     responderID: .byName(try DistinguishedName {
                         CommonName("Responder")
                     }),
-                    producedAt: try .init(Date()),
+                    producedAt: .init(Date()),
                     responses: []),
                 signatureAlgorithm: .p384PublicKey,
                 signature: ASN1BitString(bytes: [1, 2, 3, 4]), certs: nil


### PR DESCRIPTION
Currently, certificate verification is serverely bottlenecked on expiry checking. This bottleneck is almost entirely caused by converting Time objects into Date objects via DateComponents.

We can reduce the cost of this by doing fewer transformations. Instead of converting all the Time objects to Dates, we can convert a Date to a GeneralizedTime and then do all comparisons in GeneralizedTime space.

This vastly reduces the cost of cert validation.