### PR TITLE
Make constructing Dates cheaper

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -59,3 +59,12 @@ This product contains test vectors from pyca/cryptography.
     * https://github.com/pyca/cryptography/blob/main/LICENSE.APACHE
   * HOMEPAGE:
     * https://github.com/pyca/cryptography
+
+---
+
+This product contains code to calculate and decompose UNIX timestamps derived from musl libc.
+
+  * LICENSE (MIT):
+    * https://git.musl-libc.org/cgit/musl/tree/COPYRIGHT
+  * HOMEPAGE:
+    * https://musl.libc.org

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -101,6 +101,7 @@ add_library(X509
   "X509BaseTypes/SubjectPublicKeyInfo.swift"
   "X509BaseTypes/TBSCertificate.swift"
   "X509BaseTypes/Time.swift"
+  "X509BaseTypes/TimeCalculations.swift"
   "X509BaseTypes/Validity.swift")
 
 target_link_libraries(X509 PUBLIC

--- a/Sources/X509/Certificate.swift
+++ b/Sources/X509/Certificate.swift
@@ -88,15 +88,13 @@ public struct Certificate {
     /// The date before which this certificate is not valid.
     @inlinable
     public var notValidBefore: Date {
-        // TODO: Do we need to do this conversion every time? Hard to be sure.
-        // Need to work out how costly it is.
-        Date(self.tbsCertificate.validity.notBefore)!
+        Date(self.tbsCertificate.validity.notBefore)
     }
 
     /// The date after which this certificate is not valid.
     @inlinable
     public var notValidAfter: Date {
-        Date(self.tbsCertificate.validity.notAfter)!
+        Date(self.tbsCertificate.validity.notAfter)
     }
 
     /// The ``DistinguishedName`` of the issuer of this certificate.

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -471,10 +471,8 @@ extension OCSPResponseData {
     static let defaultTrustTimeLeeway: TimeInterval = 4500.0
     
     func verifyTime(validationTime: Date, trustTimeLeeway: TimeInterval = Self.defaultTrustTimeLeeway) -> PolicyEvaluationResult {
-        guard let producedAt = Date(self.producedAt) else {
-            return .failsToMeetPolicy(reason: "could not convert time specified in OCSP response to a `Date`")
-        }
-        
+        let producedAt = Date(self.producedAt)
+
         guard producedAt <= validationTime.advanced(by: trustTimeLeeway) else {
             return .failsToMeetPolicy(reason: "OCSP response `producedAt` (\(self.producedAt) is in the future (+\(trustTimeLeeway) seconds leeway) but should be in the past")
         }
@@ -494,13 +492,10 @@ extension OCSPSingleResponse {
         guard let nextUpdateGeneralizedTime = self.nextUpdate else {
             return .failsToMeetPolicy(reason: "OCSP response `nextUpdate` is nil")
         }
-        
-        guard
-            let thisUpdate = Date(self.thisUpdate),
-            let nextUpdate = Date(nextUpdateGeneralizedTime)
-        else {
-            return .failsToMeetPolicy(reason: "could not convert time specified in OCSP response to a `Date`")
-        }
+
+        let thisUpdate = Date(self.thisUpdate)
+        let nextUpdate = Date(nextUpdateGeneralizedTime)
+
         guard thisUpdate <= validationTime.advanced(by: trustTimeLeeway) else {
             return .failsToMeetPolicy(reason: "OCSP response `thisUpdate` (\(self.thisUpdate) is in the future (+\(trustTimeLeeway) seconds leeway) but should be in the past")
         }

--- a/Sources/X509/X509BaseTypes/TimeCalculations.swift
+++ b/Sources/X509/X509BaseTypes/TimeCalculations.swift
@@ -1,0 +1,263 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+// This file contains code derived from the musl implementation at
+// https://git.musl-libc.org/cgit/musl/tree/src/time/__secs_to_tm.c and
+// https://git.musl-libc.org/cgit/musl/tree/src/time/__tm_to_secs.c.
+//
+// These implementations have been translated into Swift appropriately for this
+// use-case.
+//
+// The copyright for the original implementation is:
+//
+//----------------------------------------------------------------------
+// Copyright © 2005-2020 Rich Felker, et al.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//----------------------------------------------------------------------
+
+extension Int64 {
+    // 2000-03-01 (mod 400 year, immediately after feb29
+    @inlinable
+    static var leapoch: Int64 {
+        946684800 + 86400 * (31 + 29)
+    }
+
+    @inlinable
+    static var daysPer400Years: Int64 {
+        365 * 400 + 97
+    }
+
+    @inlinable
+    static var daysPer100Years: Int64 {
+        365 * 100 + 24
+    }
+
+    @inlinable
+    static var daysPer4Years: Int64 {
+        365 * 4 + 1
+    }
+
+    @inlinable
+    static func daysInMonth(_ month: Int) -> Int64 {
+        // This may seem weird, but these months are indexed from _March_.
+        // Thus, month 0 is March, month 11 is February.
+        switch month {
+        case 0, 2, 4, 5, 7, 9, 10:
+            return 31
+        case 1, 3, 6, 8:
+            return 30
+        case 11:
+            return 29
+        default:
+            fatalError()
+        }
+    }
+
+    @inlinable
+    var utcDateFromTimestamp: (year: Int, month: Int, day: Int, hours: Int, minutes: Int, seconds: Int) {
+        let secs = self - .leapoch
+        var (days, remsecs) = secs.quotientAndRemainder(dividingBy: 86400)
+
+        // Tolerate negative values
+        if remsecs < 0 {
+            // Unchecked is safe here: we know remsecs is negative, and we know
+            // days cannot be Int64.min
+            remsecs &+= 86400
+            days &-= 1
+        }
+
+        var (qcCycles, remdays) = days.quotientAndRemainder(dividingBy: .daysPer400Years)
+        if remdays < 0 {
+            // Same justification here for unchecked arithmetic
+            remdays &+= .daysPer400Years
+            qcCycles &-= 1
+        }
+
+        // Unchecked arithmetic here is safe: the subtraction is all known values (4 - 1),
+        // and the multiplication cannot exceed the original value of remdays.
+        var cCycles = remdays / .daysPer100Years
+        if cCycles == 4 { cCycles &-= 1 }
+        remdays &-= cCycles &* .daysPer100Years
+
+        // Unchecked arithmetic here is safe: the subtraction is all known values (25 - 1),
+        // and the multiplication cannot exceed the original value of remdays.
+        var qCycles = remdays / .daysPer4Years
+        if qCycles == 25 { qCycles &-= 1 }
+        remdays &-= qCycles &* .daysPer4Years
+
+        // Unchecked arithmetic here is safe: the subtraction is all known values (4 - 1),
+        // and the multiplication cannot exceed the original value of remdays.
+        var remyears = remdays / 365
+        if remyears == 4 { remyears &-= 1 }
+        remdays &-= remyears &* 365
+
+        // Unchecked multiplication here is safe: each of these has earlier been multiplied by
+        // a much larger number and we didn't need checked math then, so we don't need it now.
+        var years = remyears + (4 &* qCycles) + (100 &* cCycles) + (400 &* qcCycles)
+
+        var months = 0
+        while Int64.daysInMonth(months) <= remdays {
+            remdays -= Int64.daysInMonth(months)
+            months += 1
+        }
+
+        // Now we normalise the months count back to starting in January.
+        // Safe to do unchecked subtraction here becuase for all numbers 10 or
+        // larger we can subtract by 12.
+        if months >= 10 {
+            months &-= 12
+            years += 1
+        }
+
+        // Normalise out the values.
+        //
+        // Safe to do unchecked math on the months as we just checked its value above.
+        // Same for remdays, the loop only terminates if the number is smaller than at most 31.
+        //
+        // Note that, unlike struct tm, we return ordinal month numbers as well as days (i.e. 1 to 12).
+        // This fits us better when working with generalizedtime and friends.
+        return (
+            year: Int(years + 2000),
+            month: Int(months &+ 3),
+            day: Int(remdays &+ 1),
+            hours: Int(remsecs / 3600),
+            minutes: Int(remsecs / 60 % 60),
+            seconds: Int(remsecs % 60)
+        )
+    }
+
+    @inlinable
+    init(timestampFromUTCDate date: (year: Int, month: Int, day: Int, hours: Int, minutes: Int, seconds: Int)) {
+        // The algorithm as written expects a tm year, which is years away from 1900, and a tm_month, which is 0-11 instead of 1-12.
+        // We don't want that nonsense. Undo it here.
+        var (seconds, isLeap) = Self.yearToSeconds(Int64(date.year) - 1900)
+        seconds += Self.monthToSeconds(Int64(date.month) - 1, isLeap: isLeap)
+
+        // Note that we tolerate invalid day/hour/minute/seconds. That's ok in this context,
+        // we validate elsewhere. However, we don't do unchecked math for that reason.
+        seconds += 86400 * (Int64(date.day) - 1)
+        seconds += 3600 * Int64(date.hours)
+        seconds += 60 * Int64(date.minutes)
+        seconds += Int64(date.seconds)
+
+        self = seconds
+    }
+
+    @inlinable
+    static func yearToSeconds(_ year: Int64) -> (seconds: Int64, isLeap: Bool) {
+        var (cycles, rem) = (year - 100).quotientAndRemainder(dividingBy: 400)
+        if rem < 0 {
+            // Unchecked is safe here: we know rem is negative, and we know
+            // cycles cannot be Int64.min
+            cycles &-= 1
+            rem &+= 400
+        }
+
+        let centuries: Int64
+        let isLeap: Bool
+        var leaps: Int64
+
+        if rem == 0 {
+            isLeap = true
+            centuries = 0
+            leaps = 0
+        } else {
+            switch rem {
+            case 300...:
+                centuries = 3
+                rem &-= 300
+            case 200...:
+                centuries = 2
+                rem &-= 200
+            case 100...:
+                centuries = 1
+                rem &-= 100
+            default:
+                assert(rem > 0)
+                centuries = 0
+            }
+
+            if rem == 0 {
+                isLeap = false
+                leaps = 0
+            } else {
+                (leaps, rem) = rem.quotientAndRemainder(dividingBy: 4)
+                isLeap = (rem == 0)
+            }
+        }
+
+        leaps += (97 * cycles) + (24 * centuries) - (isLeap ? 1 : 0)
+        return (seconds: ((year - 100) * 31536000) + (leaps * 86400) + 946684800 + 86400, isLeap: isLeap)
+    }
+
+    @inlinable
+    static func monthToSeconds(_ month: Int64, isLeap: Bool) -> Int64 {
+        var secondsThroughMonth: Int64
+
+        // musl tolerates out-of-band months: we don't.
+        switch month {
+        case 0:
+            secondsThroughMonth = 0
+        case 1:
+            secondsThroughMonth = 31*86400
+        case 2:
+            secondsThroughMonth = 59*86400
+        case 3:
+            secondsThroughMonth = 90*86400
+        case 4:
+            secondsThroughMonth = 120*86400
+        case 5:
+            secondsThroughMonth = 151*86400
+        case 6:
+            secondsThroughMonth = 181*86400
+        case 7:
+            secondsThroughMonth = 212*86400
+        case 8:
+            secondsThroughMonth = 243*86400
+        case 9:
+            secondsThroughMonth = 273*86400
+        case 10:
+            secondsThroughMonth = 304*86400
+        case 11:
+            secondsThroughMonth = 334*86400
+        default:
+            fatalError("Invalid month: \(month)")
+        }
+
+        if isLeap && month >= 2 {
+            // Unchecked is safe here, none of the above values will overflow when this is added to them.
+            secondsThroughMonth &+= 86400
+        }
+
+        return secondsThroughMonth
+    }
+}

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -711,7 +711,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         let leaf = try loadCertificate("www.apple.com", extension: "der")
         let ocspResponseLeaf = try loadOCSPResponse("www.apple.com.ocsp-response", extension: "der")
         let ocspResponseIntermediate = try loadOCSPResponse("www.apple.com.intermediate.ocsp-response", extension: "der")
-        let timeOfOCSPRequest = try Date(GeneralizedTime(year: 2023, month: 3, day: 15, hours: 15, minutes: 36, seconds: 0, fractionalSeconds: 0.0))!
+        let timeOfOCSPRequest = try Date(GeneralizedTime(year: 2023, month: 3, day: 15, hours: 15, minutes: 36, seconds: 0, fractionalSeconds: 0.0))
         
         await self.assertChain(
             soft: .meetsPolicy,

--- a/Tests/X509Tests/TimeTests.swift
+++ b/Tests/X509Tests/TimeTests.swift
@@ -21,14 +21,14 @@ final class TimeTests: XCTestCase {
         // 2022-07-01 12:15:55 corresponds to 1656677755 seconds from 1970.
         let utctime = try UTCTime(year: 2022, month: 07, day: 01, hours: 12, minutes: 15, seconds: 55)
         let expected = Date(timeIntervalSince1970: 1656677755)
-        XCTAssertEqual(expected, Date(utctime))
+        XCTAssertEqual(expected, Date(.utcTime(utctime)))
     }
 
     func testConvertGeneralizedTimeToDate() throws {
         // 2022-07-01 12:15:55 corresponds to 1656677755 seconds from 1970.
         let generalizedTime = try GeneralizedTime(year: 2022, month: 07, day: 01, hours: 12, minutes: 15, seconds: 55, fractionalSeconds: 0.0)
         let expected = Date(timeIntervalSince1970: 1656677755)
-        XCTAssertEqual(expected, Date(generalizedTime))
+        XCTAssertEqual(expected, Date(.generalTime(generalizedTime)))
     }
 
     func testConvertUTCTimeAsTimeToDate() throws {
@@ -45,5 +45,138 @@ final class TimeTests: XCTestCase {
         let time = Time.generalTime(generalizedTime)
         let expected = Date(timeIntervalSince1970: 1656677755)
         XCTAssertEqual(expected, Date(time))
+    }
+
+    func testSpecificInputsForGMTime() throws {
+        // These numbers are determined experimentally on macOS.
+        let smallestUsableTimeT = Int64(-67768040609740800)
+        let largestUsableTimeT = Int64(67768036191676799)
+        let epoch = Int64(0)
+
+        let smallestTime = smallestUsableTimeT.utcDateFromTimestamp
+        let largestTime = largestUsableTimeT.utcDateFromTimestamp
+        let epochTime = epoch.utcDateFromTimestamp
+
+        XCTAssertEqual(smallestTime.year, -2147481748)
+        XCTAssertEqual(smallestTime.month, 1)
+        XCTAssertEqual(smallestTime.day, 1)
+        XCTAssertEqual(smallestTime.hours, 0)
+        XCTAssertEqual(smallestTime.minutes, 0)
+        XCTAssertEqual(smallestTime.seconds, 0)
+
+        XCTAssertEqual(largestTime.year, 2147485547)
+        XCTAssertEqual(largestTime.month, 12)
+        XCTAssertEqual(largestTime.day, 31)
+        XCTAssertEqual(largestTime.hours, 23)
+        XCTAssertEqual(largestTime.minutes, 59)
+        XCTAssertEqual(largestTime.seconds, 59)
+
+        XCTAssertEqual(epochTime.year, 1970)
+        XCTAssertEqual(epochTime.month, 1)
+        XCTAssertEqual(epochTime.day, 1)
+        XCTAssertEqual(epochTime.hours, 0)
+        XCTAssertEqual(epochTime.minutes, 0)
+        XCTAssertEqual(epochTime.seconds, 0)
+
+        // Test we convert back correctly.
+        XCTAssertEqual(smallestUsableTimeT, Int64(timestampFromUTCDate: smallestTime))
+        XCTAssertEqual(largestUsableTimeT, Int64(timestampFromUTCDate: largestTime))
+        XCTAssertEqual(epoch, Int64(timestampFromUTCDate: epochTime))
+    }
+
+    func testCompareRandomInputsForGMTime() throws {
+        // These numbers are determined experimentally on macOS.
+        let smallestUsableTimeT = Int64(-67768040609740800)
+        let largestUsableTimeT = Int64(67768036191676799)
+
+        // If we're constrained by the system library time_t size, let's do that.
+        let lowerBound = max(smallestUsableTimeT, Int64(time_t.min))
+        let upperBound = min(largestUsableTimeT, Int64(time_t.max))
+
+        for _ in 0..<10_000 {
+            let random = Int64.random(in: lowerBound...upperBound)
+            let mine = random.utcDateFromTimestamp
+
+            var time = time_t(random)
+            var theirs = tm()
+            XCTAssertNotNil(gmtime_r(&time, &theirs), "Seed: \(random)")
+
+            XCTAssertEqual(mine.year, Int(theirs.tm_year) + 1900, "Seed: \(random)")
+            XCTAssertEqual(mine.month, Int(theirs.tm_mon) + 1, "Seed: \(random)")
+            XCTAssertEqual(mine.day, Int(theirs.tm_mday), "Seed: \(random)")
+            XCTAssertEqual(mine.hours, Int(theirs.tm_hour), "Seed: \(random)")
+            XCTAssertEqual(mine.minutes, Int(theirs.tm_min), "Seed: \(random)")
+            XCTAssertEqual(mine.seconds, Int(theirs.tm_sec), "Seed: \(random)")
+
+            let returned = Int64(timestampFromUTCDate: mine)
+            XCTAssertEqual(returned, random)
+        }
+    }
+
+    func testHandleDaysAndLeapYearsProperly() throws {
+        // Start from Sat, 01 Jan 1600 00:00:00 and test every day between then and the year 3000.
+        // This tests our year-based computations are probably correct.
+        var timestamp = Int64(-11676096000)
+        
+        for year in 1600..<3000 {
+            let isLeapYear = (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+            
+            for month in 1...12 {
+                let days: Int
+                
+                switch month {
+                case 1, 3, 5, 7, 8, 10, 12:
+                    days = 31
+                case 4, 6, 9, 11:
+                    days = 30
+                case 2:
+                    days = isLeapYear ? 29 : 28
+                default:
+                    fatalError()
+                }
+                
+                for day in 1...days {
+                    let computed = timestamp.utcDateFromTimestamp
+                    
+                    XCTAssertEqual(computed.year, year)
+                    XCTAssertEqual(computed.month, month)
+                    XCTAssertEqual(computed.day, day)
+                    XCTAssertEqual(computed.hours, 0)
+                    XCTAssertEqual(computed.minutes, 0)
+                    XCTAssertEqual(computed.seconds, 0)
+                    
+                    let reversed = Int64(timestampFromUTCDate: computed)
+                    XCTAssertEqual(reversed, timestamp)
+                    
+                    // The number of seconds in 1 day.
+                    timestamp += 24 * 60 * 60
+                }
+            }
+        }
+    }
+
+    func testWeHandleHoursMinutesAndSecondsProperly() throws {
+        var timestamp = Int64(0)
+
+        for hours in 0..<24 {
+            for minutes in 0..<60 {
+                for seconds in 0..<60 {
+                    let computed = timestamp.utcDateFromTimestamp
+
+                    XCTAssertEqual(computed.year, 1970)
+                    XCTAssertEqual(computed.month, 1)
+                    XCTAssertEqual(computed.day, 1)
+                    XCTAssertEqual(computed.hours, hours)
+                    XCTAssertEqual(computed.minutes, minutes)
+                    XCTAssertEqual(computed.seconds, seconds)
+
+                    let reversed = Int64(timestampFromUTCDate: computed)
+                    XCTAssertEqual(reversed, timestamp)
+
+                    // Add 1 second and keep going.
+                    timestamp += 1
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Translating between Date and Time is expensive when we use DateComponents, because we jump through ICU unnecessarily. We can move over to standard UTC date math instead, which makes this process vastly cheaper.