### PR TITLE
Police uniqueness of `ExtendedKeyUsage`

### DIFF
--- a/Sources/X509/Extension Types/AuthorityInformationAccess.swift
+++ b/Sources/X509/Extension Types/AuthorityInformationAccess.swift
@@ -73,7 +73,6 @@ extension AuthorityInformationAccess: RandomAccessCollection {
 
     @inlinable
     public subscript(position: Int) -> AccessDescription {
-        // TODO(cory): Maintain uniqueness
         get {
             self.descriptions[position]
         }

--- a/Sources/X509/Extension Types/ExtendedKeyUsage.swift
+++ b/Sources/X509/Extension Types/ExtendedKeyUsage.swift
@@ -36,9 +36,7 @@ public struct ExtendedKeyUsage {
             for currentIndex in self.usages.indices.dropFirst(index + 1) {
                 let currentUsage = self.usages[currentIndex]
                 if usage == currentUsage {
-                    fatalError("duplicate")
-                    #warning("throw error once new error case lands")
-                    //throw CertificateError.duplicateOID(reason: "duplicate \(usage) usage. First at \(index) and second at \(currentIndex)")
+                    throw CertificateError.duplicateOID(reason: "duplicate \(usage) usage. First at \(index) and second at \(currentIndex)")
                 }
             }
         }

--- a/Sources/X509/Extension Types/ExtendedKeyUsage.swift
+++ b/Sources/X509/Extension Types/ExtendedKeyUsage.swift
@@ -107,12 +107,7 @@ extension ExtendedKeyUsage {
     @inlinable
     @discardableResult
     public mutating func append(_ usage: Element) -> (inserted: Bool, index: Int) {
-        guard let index = self.firstIndex(of: usage) else {
-            let index = self.endIndex
-            self.usages.append(usage)
-            return (inserted: true, index: index)
-        }
-        return (inserted: false, index: index)
+        self.insert(usage, at: self.endIndex)
     }
     
     /// Insert a new `usage` to this set at the specified index, if `self` doesn't

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -66,7 +66,7 @@ struct OCSPResponderSigningPolicy: VerifierPolicy {
             return .failsToMeetPolicy(reason: "OCSP response certificate has no extended key usages")
         }
 
-        guard extendedKeyUsage.usages.contains(.init(oid: .ExtendedKeyUsage.ocspSigning)) else {
+        guard extendedKeyUsage.usages.contains(.ocspSigning) else {
             return .failsToMeetPolicy(reason: "OCSP response certificate does not have OCSP signing extended key usage set")
         }
         

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -216,7 +216,7 @@ final class CertificateDERTests: XCTestCase {
         )
         XCTAssertEqual(
             try cert.extensions.extendedKeyUsage,
-            .init([.serverAuth, .clientAuth])
+            try .init([.serverAuth, .clientAuth])
         )
         XCTAssertEqual(
             try cert.extensions.basicConstraints,
@@ -243,7 +243,7 @@ final class CertificateDERTests: XCTestCase {
                 KeyUsage(digitalSignature: true, keyCertSign: true, cRLSign: true)
             )
 
-            ExtendedKeyUsage([.serverAuth, .clientAuth])
+            try ExtendedKeyUsage([.serverAuth, .clientAuth])
 
             Critical(
                 BasicConstraints.isCertificateAuthority(maxPathLength: 0)

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -242,7 +242,7 @@ final class CertificateTests: XCTestCase {
     }
 
     func testPrintingEKU() throws {
-        let eku = ExtendedKeyUsage([
+        let eku = try ExtendedKeyUsage([
             .any,
             .certificateTransparency,
             .timeStamping,

--- a/Tests/X509Tests/ExtendedKeyUsageTests.swift
+++ b/Tests/X509Tests/ExtendedKeyUsageTests.swift
@@ -1,0 +1,122 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import X509
+
+final class ExtendedKeyUsageTests: XCTestCase {
+    func testInit() {
+        //        XCTAssertThrowsError(try ExtendedKeyUsage([
+        //            .serverAuth,
+        //            .serverAuth,
+        //        ])) { error in
+        //            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
+        //        }
+        //
+        //        XCTAssertThrowsError(try ExtendedKeyUsage([
+        //            .clientAuth,
+        //            .serverAuth,
+        //            .clientAuth,
+        //        ])) { error in
+        //            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
+        //        }
+    }
+    
+    func testInsert() throws {
+        var usages = try ExtendedKeyUsage([
+            .serverAuth,
+        ])
+        XCTAssertTrue(usages.insert(.clientAuth, at: 1) == (true, 1))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+            .clientAuth,
+        ]))
+        XCTAssertTrue(usages.insert(.clientAuth, at: 1) == (false, 1))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+            .clientAuth,
+        ]))
+        XCTAssertTrue(usages.insert(.ocspSigning, at: 1) == (true, 1))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+            .ocspSigning,
+            .clientAuth,
+        ]))
+        XCTAssertTrue(usages.insert(.codeSigning, at: 0) == (true, 0))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .codeSigning,
+            .serverAuth,
+            .ocspSigning,
+            .clientAuth,
+        ]))
+    }
+    
+    func testAppend() throws {
+        var usages = ExtendedKeyUsage()
+        
+        usages.append(.clientAuth)
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .clientAuth,
+        ]))
+        
+        usages.append(.clientAuth)
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .clientAuth,
+        ]))
+        
+        usages.append(.ocspSigning)
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .clientAuth,
+            .ocspSigning,
+        ]))
+    }
+    
+    func testRemove() throws {
+        var usages = try ExtendedKeyUsage([
+            .clientAuth,
+            .serverAuth,
+            .ocspSigning,
+        ])
+        
+        XCTAssertNil(usages.remove(.emailProtection))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .clientAuth,
+            .serverAuth,
+            .ocspSigning,
+        ]))
+        
+        XCTAssertEqual(usages.remove(.clientAuth), .clientAuth)
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+            .ocspSigning,
+        ]))
+        
+        XCTAssertNil(usages.remove(.clientAuth))
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+            .ocspSigning,
+        ]))
+        
+        XCTAssertEqual(usages.remove(.ocspSigning), .ocspSigning)
+        XCTAssertEqual(usages, try ExtendedKeyUsage([
+            .serverAuth,
+        ]))
+        
+        XCTAssertEqual(usages.remove(.serverAuth), .serverAuth)
+        XCTAssertEqual(usages, ExtendedKeyUsage())
+        
+        XCTAssertNil(usages.remove(.serverAuth))
+        XCTAssertEqual(usages, ExtendedKeyUsage())
+    }
+}

--- a/Tests/X509Tests/ExtendedKeyUsageTests.swift
+++ b/Tests/X509Tests/ExtendedKeyUsageTests.swift
@@ -17,20 +17,20 @@ import X509
 
 final class ExtendedKeyUsageTests: XCTestCase {
     func testInit() {
-        //        XCTAssertThrowsError(try ExtendedKeyUsage([
-        //            .serverAuth,
-        //            .serverAuth,
-        //        ])) { error in
-        //            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
-        //        }
-        //
-        //        XCTAssertThrowsError(try ExtendedKeyUsage([
-        //            .clientAuth,
-        //            .serverAuth,
-        //            .clientAuth,
-        //        ])) { error in
-        //            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
-        //        }
+        XCTAssertThrowsError(try ExtendedKeyUsage([
+            .serverAuth,
+            .serverAuth,
+        ])) { error in
+            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
+        }
+        
+        XCTAssertThrowsError(try ExtendedKeyUsage([
+            .clientAuth,
+            .serverAuth,
+            .clientAuth,
+        ])) { error in
+            XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
+        }
     }
     
     func testInsert() throws {

--- a/Tests/X509Tests/ExtensionBuilderTests.swift
+++ b/Tests/X509Tests/ExtensionBuilderTests.swift
@@ -183,12 +183,13 @@ final class ExtensionBuilderTests: XCTestCase {
         }
         
         XCTAssertThrowsError(try Certificate.Extensions {
-            ExtendedKeyUsage([.serverAuth])
-            ExtendedKeyUsage([.clientAuth])
+            try ExtendedKeyUsage([.serverAuth])
+            try ExtendedKeyUsage([.clientAuth])
         }) { error in
             XCTAssertEqual((error as? CertificateError)?.code, .duplicateOID, "wrong error \(error)")
         }
     }
+    
     func testAppend() {
         var extensions = Certificate.Extensions()
         XCTAssertNoThrow(try extensions.append(.init(oid: [1], critical: false, value: [1])))


### PR DESCRIPTION
### Motivation
`ExtendedKeyUsage` is only allowed to each `Usage` at most once. It models an `OrderedSet` and should have a similar API surface.

### Modification
- `ExtendedKeyUsage.init(_:)` now throws an error if a duplicate `Usage` is encountered.
- add `append(_:)` method to insert a `Usage` at the end of set if not already present.
- add `insert(_:at:)` method to insert a `Usage` at a specific index if not already present.
- add `remove(_:)` method to remove a `Usage` if present.
- remove `subscribe(position:)` setter because it can't safely enforce the uniqueness constraint without crashing. `OrderedSet` doesn't either.

Unrelated to `ExtendedKeyUsage` but related to a similar TODO:
- We don't need to maintain uniqueness for `AuthorityInformationAccess`. Was probably a copy and past error. TODO therefore removed.

### Result
`ExtendedKeyUsage` now properly maintains uniqueness.