### PR TITLE
We aren't supporting PSS for now.

### DIFF
--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -135,7 +135,8 @@ extension Certificate.PublicKey {
         case .p521(let p521):
             return p521.isValidSignature(signature, for: digest)
         case .rsa(let rsa):
-            // TODO: Extend for PSS?
+            // For now we don't support RSA PSS, as it's not deployed in the WebPKI.
+            // We could, if there are sufficient user needs.
             do {
                 let padding = try _RSA.Signing.Padding(forSignatureAlgorithm: signatureAlgorithm)
                 return rsa.isValidSignature(signature, for: digest, padding: padding)

--- a/Sources/X509/X509BaseTypes/AlgorithmIdentifier.swift
+++ b/Sources/X509/X509BaseTypes/AlgorithmIdentifier.swift
@@ -211,7 +211,6 @@ extension AlgorithmIdentifier: CustomStringConvertible {
     }
 }
 
-// TODO(cory): We need representations for RSA-PSS. See RFC 4055 for descriptions of the ASN.1.
 // Relevant note: the PKCS1v1.5 versions need to treat having no parameters and a NULL parameters as identical. This is probably general,
 // so we may need a custom equatable implementation there.
 


### PR DESCRIPTION
RSA PSS isn't really deployed in the WebPKI, and with the recent interest in post-quantum crypto it seems unlikely a new RSA padding mode will be specified. Let's not allude to trying to support it.