### PR TITLE
Limit the number elements in `Extensions` and `ExtendedKeyUsage`

### DIFF
--- a/Sources/X509/Extension Types/ExtendedKeyUsage.swift
+++ b/Sources/X509/Extension Types/ExtendedKeyUsage.swift
@@ -29,7 +29,12 @@ public struct ExtendedKeyUsage {
     public init<Usages: Sequence>(_ usages: Usages) throws where Usages.Element == Usage {
         self.usages = Array(usages)
         
-        let maxUsages = 16
+        // This limit is somewhat arbitrary. Linear search for under 32 elements
+        // is faster than hashing and fast enough to not be a significant performance bottleneck.
+        // We have this limit because a bad actor could increase the number of elements to an arbitrary number which
+        // will increase our decoding time exponentially.
+        // This can be used for DoS attacks so we have added this limit.
+        let maxUsages = 32
         guard self.usages.count <= maxUsages else {
             throw ASN1Error.invalidASN1Object(reason: "Too many extended key usages. Found \(self.usages.count) but only \(maxUsages) are allowed.")
         }

--- a/Sources/X509/Extension Types/ExtendedKeyUsage.swift
+++ b/Sources/X509/Extension Types/ExtendedKeyUsage.swift
@@ -29,6 +29,11 @@ public struct ExtendedKeyUsage {
     public init<Usages: Sequence>(_ usages: Usages) throws where Usages.Element == Usage {
         self.usages = Array(usages)
         
+        let maxUsages = 16
+        guard self.usages.count <= maxUsages else {
+            throw ASN1Error.invalidASN1Object(reason: "Too many extended key usages. Found \(self.usages.count) but only \(maxUsages) are allowed.")
+        }
+        
         if let (firstIndex, secondIndex) = self.usages.findDuplicates(by: ==) {
             let usage = self.usages[firstIndex]
             throw CertificateError.duplicateOID(reason: "duplicate \(usage) usage. First at \(firstIndex) and second at \(secondIndex)")

--- a/Sources/X509/Extensions.swift
+++ b/Sources/X509/Extensions.swift
@@ -89,6 +89,11 @@ extension Certificate {
         public init<Elements>(_ extensions: Elements) throws where Elements: Sequence, Elements.Element == Extension {
             self._extensions = Array(extensions)
             
+            let maxExtensions = 16
+            guard self._extensions.count <= maxExtensions else {
+                throw ASN1Error.invalidASN1Object(reason: "Too many extensions. Found \(self._extensions.count) but only \(maxExtensions) are allowed.")
+            }
+            
             if let (firstIndex, secondIndex) = self._extensions.findDuplicates(by: { $0.oid == $1.oid }) {
                 let firstExt = self._extensions[firstIndex]
                 let secondExt = self._extensions[secondIndex]

--- a/Sources/X509/Extensions.swift
+++ b/Sources/X509/Extensions.swift
@@ -89,7 +89,12 @@ extension Certificate {
         public init<Elements>(_ extensions: Elements) throws where Elements: Sequence, Elements.Element == Extension {
             self._extensions = Array(extensions)
             
-            let maxExtensions = 16
+            // This limit is somewhat arbitrary. Linear search for under 32 elements
+            // is faster than hashing and fast enough to not be a significant performance bottleneck.
+            // We have this limit because a bad actor could increase the number of elements to an arbitrary number which
+            // will increase our decoding time exponentially.
+            // This can be used for DoS attacks so we have added this limit.
+            let maxExtensions = 32
             guard self._extensions.count <= maxExtensions else {
                 throw ASN1Error.invalidASN1Object(reason: "Too many extensions. Found \(self._extensions.count) but only \(maxExtensions) are allowed.")
             }

--- a/Tests/X509Tests/ExtendedKeyUsageTests.swift
+++ b/Tests/X509Tests/ExtendedKeyUsageTests.swift
@@ -119,4 +119,21 @@ final class ExtendedKeyUsageTests: XCTestCase {
         XCTAssertNil(usages.remove(.serverAuth))
         XCTAssertEqual(usages, ExtendedKeyUsage())
     }
+    
+    func testLargeNumberOfExtensions() throws {
+        let usages = try ExtendedKeyUsage((0..<16).map {
+            ExtendedKeyUsage.Usage(oid: [$0])
+        })
+        XCTAssertEqual(usages.count, 16)
+    }
+    
+    func testUnreasonableLargeNumberOfExtensionsAreRejected() {
+        XCTAssertThrowsError(try ExtendedKeyUsage((0..<17).map {
+            ExtendedKeyUsage.Usage(oid: [$0])
+        }))
+        
+        XCTAssertThrowsError(try ExtendedKeyUsage((0..<10_000).map {
+            ExtendedKeyUsage.Usage(oid: [$0])
+        }))
+    }
 }

--- a/Tests/X509Tests/ExtendedKeyUsageTests.swift
+++ b/Tests/X509Tests/ExtendedKeyUsageTests.swift
@@ -121,14 +121,14 @@ final class ExtendedKeyUsageTests: XCTestCase {
     }
     
     func testLargeNumberOfExtensions() throws {
-        let usages = try ExtendedKeyUsage((0..<16).map {
+        let usages = try ExtendedKeyUsage((0..<32).map {
             ExtendedKeyUsage.Usage(oid: [$0])
         })
-        XCTAssertEqual(usages.count, 16)
+        XCTAssertEqual(usages.count, 32)
     }
     
     func testUnreasonableLargeNumberOfExtensionsAreRejected() {
-        XCTAssertThrowsError(try ExtendedKeyUsage((0..<17).map {
+        XCTAssertThrowsError(try ExtendedKeyUsage((0..<33).map {
             ExtendedKeyUsage.Usage(oid: [$0])
         }))
         

--- a/Tests/X509Tests/ExtensionBuilderTests.swift
+++ b/Tests/X509Tests/ExtensionBuilderTests.swift
@@ -238,14 +238,14 @@ final class ExtensionBuilderTests: XCTestCase {
     }
     
     func testLargeNumberOfExtensions() throws {
-        let ext = try Certificate.Extensions((0..<16).map {
+        let ext = try Certificate.Extensions((0..<32).map {
             Certificate.Extension(oid: [$0], critical: false, value: [1, 2, 3, 4])
         })
-        XCTAssertEqual(ext.count, 16)
+        XCTAssertEqual(ext.count, 32)
     }
     
     func testUnreasonableLargeNumberOfExtensionsAreRejected() {
-        XCTAssertThrowsError(try Certificate.Extensions((0..<17).map {
+        XCTAssertThrowsError(try Certificate.Extensions((0..<33).map {
             Certificate.Extension(oid: [$0], critical: false, value: [1, 2, 3, 4])
         }))
         

--- a/Tests/X509Tests/ExtensionBuilderTests.swift
+++ b/Tests/X509Tests/ExtensionBuilderTests.swift
@@ -236,4 +236,21 @@ final class ExtensionBuilderTests: XCTestCase {
         extensions.remove([1])
         XCTAssertEqual(extensions, Certificate.Extensions())
     }
+    
+    func testLargeNumberOfExtensions() throws {
+        let ext = try Certificate.Extensions((0..<16).map {
+            Certificate.Extension(oid: [$0], critical: false, value: [1, 2, 3, 4])
+        })
+        XCTAssertEqual(ext.count, 16)
+    }
+    
+    func testUnreasonableLargeNumberOfExtensionsAreRejected() {
+        XCTAssertThrowsError(try Certificate.Extensions((0..<17).map {
+            Certificate.Extension(oid: [$0], critical: false, value: [1, 2, 3, 4])
+        }))
+        
+        XCTAssertThrowsError(try Certificate.Extensions((0..<10_000).map {
+            Certificate.Extension(oid: [$0], critical: false, value: [1, 2, 3, 4])
+        }))
+    }
 }


### PR DESCRIPTION
### Motivation
When decoding a certificate we make sure that `ExtendedKeyUsage` and `Certificate.Extensions` only contain unique elements.
In the real world those collections are fairly small and we therefore use a linear scan to check for duplicates and fail decoding if we detect a duplicate.
However, a bad actor could increase the number of elements to an arbitrary number which will increase our decoding time exponentially.

### Modification
Limit the number of elements we accept to 16 before we do the uniqueness check

### Result
We safely fail decoding for unreasonable large number of elements.

Note that if we encounter a real world use case for more elements we can also switch to hash based uniqueness check and support more elements safely.