### PR TITLE
Implement TinyArray

### DIFF
--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
@@ -12,14 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(IntegrationTests) import X509
+import _CertificateInternals
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        var tinyArray = TinyArray<Int>()
-        for i in 0..<1000 {
-            tinyArray.append(i)
+        var count = 0
+        for _ in 0..<1000 {
+            var tinyArray = _TinyArray<Int>()
+            for i in 0..<1000 {
+                tinyArray.append(i)
+            }
+            count += tinyArray.count
         }
-        return tinyArray.count
+        
+        return count
     }
 }

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
@@ -16,16 +16,15 @@
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        var array = Array<Int>()
-        array.reserveCapacity(4)
-        array.append(1)
-        array.append(2)
-        var tinyArray = TinyArray(array)
-        // drop the ref to array so TinyArray is now the single owner
-        array = []
-        
+        var tinyArray = TinyArray<Int>()
+        tinyArray.append(1)
+        tinyArray.append(2)
         tinyArray.append(3)
         tinyArray.append(4)
+        tinyArray.append(5)
+        tinyArray.append(6)
+        tinyArray.append(7)
+        tinyArray.append(8)
         return tinyArray.count
     }
 }

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
@@ -17,14 +17,9 @@
 func run(identifier: String) {
     measure(identifier: identifier) {
         var tinyArray = TinyArray<Int>()
-        tinyArray.append(1)
-        tinyArray.append(2)
-        tinyArray.append(3)
-        tinyArray.append(4)
-        tinyArray.append(5)
-        tinyArray.append(6)
-        tinyArray.append(7)
-        tinyArray.append(8)
+        for i in 0..<1000 {
+            tinyArray.append(i)
+        }
         return tinyArray.count
     }
 }

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_cow_append_contents_of.swift
@@ -12,10 +12,20 @@
 //
 //===----------------------------------------------------------------------===//
 
-import X509
+@_spi(IntegrationTests) import X509
 
 func run(identifier: String) {
     measure(identifier: identifier) {
-        return 0
+        var array = Array<Int>()
+        array.reserveCapacity(4)
+        array.append(1)
+        array.append(2)
+        var tinyArray = TinyArray(array)
+        // drop the ref to array so TinyArray is now the single owner
+        array = []
+        
+        tinyArray.append(3)
+        tinyArray.append(4)
+        return tinyArray.count
     }
 }

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
@@ -15,9 +15,9 @@
 @_spi(IntegrationTests) import X509
 
 func run(identifier: String) {
-    let preallocatedArray1 = [1, 2, 3, 4]
-    let preallocatedArray2 = [1, 2, 3, 4]
-    let preallocatedArray3 = [1, 2, 3, 4]
+    let preallocatedArray1 = [1]
+    let preallocatedArray2 = [1, 2]
+    let preallocatedArray3 = [1, 2, 3]
     let preallocatedArray4 = [1, 2, 3, 4]
 
     measure(identifier: identifier) {

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
@@ -15,46 +15,13 @@
 @_spi(IntegrationTests) import X509
 
 func run(identifier: String) {
-    let preallocatedArray1 = [1]
-    let preallocatedArray2 = [1, 2]
-    let preallocatedArray3 = [1, 2, 3]
-    let preallocatedArray4 = [1, 2, 3, 4]
-
     measure(identifier: identifier) {
         var counts = 0
         counts += TinyArray(CollectionOfOne(1)).count
-        counts += TinyArray(preallocatedArray1).count
-        counts += TinyArray(preallocatedArray2).count
-        counts += TinyArray(preallocatedArray3).count
-        counts += TinyArray(preallocatedArray4).count
         
         do {
             var array = TinyArray<Int>()
             array.append(contentsOf: CollectionOfOne(1))
-            counts += array.count
-        }
-        
-        do {
-            var array = TinyArray<Int>()
-            array.append(contentsOf: preallocatedArray1)
-            counts += array.count
-        }
-        
-        do {
-            var array = TinyArray<Int>()
-            array.append(contentsOf: preallocatedArray2)
-            counts += array.count
-        }
-        
-        do {
-            var array = TinyArray<Int>()
-            array.append(contentsOf: preallocatedArray3)
-            counts += array.count
-        }
-        
-        do {
-            var array = TinyArray<Int>()
-            array.append(contentsOf: preallocatedArray4)
             counts += array.count
         }
         

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
@@ -1,0 +1,63 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(IntegrationTests) import X509
+
+func run(identifier: String) {
+    let preallocatedArray1 = [1, 2, 3, 4]
+    let preallocatedArray2 = [1, 2, 3, 4]
+    let preallocatedArray3 = [1, 2, 3, 4]
+    let preallocatedArray4 = [1, 2, 3, 4]
+
+    measure(identifier: identifier) {
+        var counts = 0
+        counts += TinyArray(CollectionOfOne(1)).count
+        counts += TinyArray(preallocatedArray1).count
+        counts += TinyArray(preallocatedArray2).count
+        counts += TinyArray(preallocatedArray3).count
+        counts += TinyArray(preallocatedArray4).count
+        
+        do {
+            var array = TinyArray<Int>()
+            array.append(contentsOf: CollectionOfOne(1))
+            counts += array.count
+        }
+        
+        do {
+            var array = TinyArray<Int>()
+            array.append(contentsOf: preallocatedArray1)
+            counts += array.count
+        }
+        
+        do {
+            var array = TinyArray<Int>()
+            array.append(contentsOf: preallocatedArray2)
+            counts += array.count
+        }
+        
+        do {
+            var array = TinyArray<Int>()
+            array.append(contentsOf: preallocatedArray3)
+            counts += array.count
+        }
+        
+        do {
+            var array = TinyArray<Int>()
+            array.append(contentsOf: preallocatedArray4)
+            counts += array.count
+        }
+        
+        return counts
+    }
+}

--- a/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
+++ b/IntegrationTests/tests_01_allocation_counters/test_01_resources/test_tiny_array_non_allocating_operations.swift
@@ -12,17 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_spi(IntegrationTests) import X509
+import _CertificateInternals
 
 func run(identifier: String) {
     measure(identifier: identifier) {
         var counts = 0
-        counts += TinyArray(CollectionOfOne(1)).count
-        
-        do {
-            var array = TinyArray<Int>()
-            array.append(contentsOf: CollectionOfOne(1))
-            counts += array.count
+        for _ in 0..<1000 {
+            counts += _TinyArray(CollectionOfOne(1)).count
+            
+            do {
+                var array = _TinyArray<Int>()
+                array.append(contentsOf: CollectionOfOne(1))
+                counts += array.count
+            }
         }
         
         return counts

--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
         .target(
             name: "X509",
             dependencies: [
+                "_CertificateInternals",
                 .product(name: "SwiftASN1", package: "swift-asn1"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "_CryptoExtras", package: "swift-crypto"),
@@ -54,6 +55,16 @@ let package = Package(
                 .copy("OCSP Test Resources/www.apple.com.intermediate.ocsp-response.der"),
                 .copy("PEMTestRSACertificate.pem"),
                 .copy("CSR Vectors/"),
+            ]),
+        .target(
+            name: "_CertificateInternals",
+            exclude: [
+                "CMakeLists.txt",
+            ]),
+        .testTarget(
+            name: "CertificateInternalsTests",
+            dependencies: [
+                "_CertificateInternals",
             ]),
     ]
 )

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -81,6 +81,7 @@ add_library(X509
   "SEC1PrivateKey.swift"
   "Signature.swift"
   "SignatureAlgorithm.swift"
+  "TinyArray.swift"
   "Verifier/AnyPolicy.swift"
   "Verifier/CertificateStore.swift"
   "Verifier/PolicyBuilder.swift"

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -81,7 +81,6 @@ add_library(X509
   "SEC1PrivateKey.swift"
   "Signature.swift"
   "SignatureAlgorithm.swift"
-  "TinyArray.swift"
   "Verifier/AnyPolicy.swift"
   "Verifier/CertificateStore.swift"
   "Verifier/PolicyBuilder.swift"

--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -109,7 +109,8 @@ target_link_libraries(X509 PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   Crypto
   _CryptoExtras
-  SwiftASN1)
+  SwiftASN1
+  _CertificateInternals)
 set_target_properties(X509 PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 

--- a/Sources/X509/TinyArray.swift
+++ b/Sources/X509/TinyArray.swift
@@ -1,0 +1,230 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+/// ``TinyArray`` is optimized to store zero or one ``Element``.
+/// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate seperate storage on the heap and
+/// instead stores the ``Element`` inline.
+@usableFromInline
+enum TinyArray<Element>: RandomAccessCollection {
+    @usableFromInline
+    typealias Element = Element
+    
+    @usableFromInline
+    typealias Index = Int
+    
+    case one(Element)
+    // we need to garantee that .arbitary never contains exectly one element,
+    // otherwise the autosyntesized `Eqautable` and `Hashable` implementations
+    // would be wrong because `.one(1) != .arbitary([1])`.
+    // This is in general not a problem but we would need to implement it accordingly.
+    case arbitary([Element])
+    
+    @inlinable
+    subscript(position: Int) -> Element {
+        get {
+            switch self {
+            case .one(let element):
+                guard position == 0 else {
+                    fatalError("index \(position) out of bounds")
+                }
+                return element
+            case .arbitary(let elements):
+                return elements[position]
+            }
+        }
+    }
+    
+    @inlinable
+    var startIndex: Int {
+        0
+    }
+    
+    @inlinable
+    var endIndex: Int {
+        switch self {
+        case .one: return 1
+        case .arbitary(let elements): return elements.endIndex
+        }
+    }
+    
+    @inlinable
+    init(_ elements: some Sequence<Element>) {
+        self = .arbitary([])
+        self.append(contentsOf: elements)
+    }
+    
+    @inlinable
+    init(_ newElements: some Sequence<Result<Element, some Error>>) throws {
+        var iterator = newElements.makeIterator()
+        guard let firstElement = try iterator.next()?.get() else {
+            self = .arbitary([])
+            return
+        }
+        guard let secondElement = try iterator.next()?.get() else {
+            // newElements just contains a single element
+            // and we hit the fast path
+            self = .one(firstElement)
+            return
+        }
+        
+        var elements: [Element] = []
+        elements.reserveCapacity(newElements.underestimatedCount)
+        elements.append(firstElement)
+        elements.append(secondElement)
+        while let nextElement = try iterator.next()?.get() {
+            elements.append(nextElement)
+        }
+        self = .arbitary(elements)
+    }
+    
+    @inlinable
+    init() {
+        self = .arbitary([])
+    }
+    
+    @inlinable
+    mutating func append(_ newElement: Element) {
+        self.append(contentsOf: CollectionOfOne(newElement))
+    }
+    
+    @inlinable
+    mutating func append(contentsOf newElements: some Sequence<Element>){
+        switch self {
+        case .one(let firstElement):
+            var iterator = newElements.makeIterator()
+            guard let secondElement = iterator.next() else {
+                // newElements is empty, nothing to do
+                return
+            }
+            var elements: [Element] = []
+            elements.reserveCapacity(1 + newElements.underestimatedCount)
+            elements.append(firstElement)
+            elements.append(secondElement)
+            elements.appendRemainingElements(from: &iterator)
+            self = .arbitary(elements)
+            
+        case .arbitary(var elements):
+            if elements.isEmpty {
+                if let array = newElements as? Array<Element> {
+                    if array.count == 1 {
+                        self = .one(array[0])
+                    } else {
+                        self = .arbitary(array)
+                    }
+                } else {
+                    // if `self` is currently empty and `newElements` just contains a single
+                    // element, we skip allocating an array and set `self` to `.one(firstElement)`
+                    var iterator = newElements.makeIterator()
+                    guard let firstElement = iterator.next() else {
+                        // newElements is empty, nothing to do
+                        return
+                    }
+                    guard let secondElement = iterator.next() else {
+                        // newElements just contains a single element
+                        // and we hit the fast path
+                        self = .one(firstElement)
+                        return
+                    }
+                    elements.reserveCapacity(elements.count + newElements.underestimatedCount)
+                    elements.append(firstElement)
+                    elements.append(secondElement)
+                    elements.appendRemainingElements(from: &iterator)
+                    self = .arbitary(elements)
+                }
+            } else {
+                elements.append(contentsOf: newElements)
+                self = .arbitary(elements)
+            }
+            
+        }
+    }
+    
+    @discardableResult
+    @inlinable
+    mutating func remove(at index: Int) -> Element {
+        switch self {
+        case .one(let oldElement):
+            guard index == 0 else {
+                fatalError("index \(index) out of bounds")
+            }
+            self = .arbitary([])
+            return oldElement
+            
+        case .arbitary(var elements):
+            defer {
+                if elements.count == 1 {
+                    self = .one(elements[0])
+                } else {
+                    self = .arbitary(elements)
+                }
+            }
+
+            return elements.remove(at: index)
+        }
+    }
+    
+    @inlinable
+    mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+        switch self {
+        case .one(let oldElement):
+            if try shouldBeRemoved(oldElement) {
+                self = .arbitary([])
+            }
+            
+        case .arbitary(var elements):
+            defer {
+                if elements.count == 1 {
+                    self = .one(elements[0])
+                } else {
+                    self = .arbitary(elements)
+                }
+            }
+            
+            return try elements.removeAll(where: shouldBeRemoved)
+        }
+    }
+    
+    @inlinable
+    mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+        switch self {
+        case .one:
+            // a collection of just one element is always sorted, nothing to do
+            break
+        case .arbitary(var elements):
+            defer {
+                // sorting doesn't change the number of elements
+                // so we don't need to check the size
+                self = .arbitary(elements)
+            }
+            
+            try elements.sort(by: areInIncreasingOrder)
+        }
+    }
+}
+
+extension TinyArray: Equatable where Element: Equatable {}
+extension TinyArray: Hashable where Element: Hashable {}
+extension TinyArray: Sendable where Element: Sendable {}
+
+
+extension Array {
+    @inlinable
+    mutating func appendRemainingElements(from iterator: inout some IteratorProtocol<Element>) {
+        while let nextElement = iterator.next() {
+            append(nextElement)
+        }
+    }
+}

--- a/Sources/X509/TinyArray.swift
+++ b/Sources/X509/TinyArray.swift
@@ -17,8 +17,7 @@ import Foundation
 /// ``TinyArray`` is a ``RandomAccessCollection`` optimised to store zero or one ``Element``.
 /// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate separate storage on the heap
 /// and instead stores the ``Element`` inline.
-@usableFromInline
-struct TinyArray<Element> {
+@_spi(IntegrationTests) public struct TinyArray<Element> {
     @usableFromInline
     enum Storage {
         case one(Element)
@@ -36,69 +35,67 @@ extension TinyArray: Hashable where Element: Hashable {}
 extension TinyArray: Sendable where Element: Sendable {}
 
 extension TinyArray: RandomAccessCollection {
-    @usableFromInline
-    typealias Element = Element
+    @_spi(IntegrationTests) public typealias Element = Element
     
-    @usableFromInline
-    typealias Index = Int
+    @_spi(IntegrationTests) public typealias Index = Int
     
     @inlinable
-    subscript(position: Int) -> Element {
+    @_spi(IntegrationTests) public subscript(position: Int) -> Element {
         get {
             self.storage[position]
         }
     }
     
     @inlinable
-    var startIndex: Int {
+    @_spi(IntegrationTests) public var startIndex: Int {
         self.storage.startIndex
     }
     
     @inlinable
-    var endIndex: Int {
+    @_spi(IntegrationTests) public var endIndex: Int {
         self.storage.endIndex
     }
 }
 
 extension TinyArray {
     @inlinable
-    init(_ elements: some Sequence<Element>) {
+    @_spi(IntegrationTests) public init(_ elements: some Sequence<Element>) {
         self.storage = .init(elements)
     }
     
     @inlinable
-    init(_ elements: some Sequence<Result<Element, some Error>>) throws {
+    @_spi(IntegrationTests) public init(_ elements: some Sequence<Result<Element, some Error>>) throws {
         self.storage = try .init(elements)
     }
     
     @inlinable
-    init() {
+    @_spi(IntegrationTests) public init() {
         self.storage = .init()
     }
     
     @inlinable
-    mutating func append(_ newElement: Element) {
+    @_spi(IntegrationTests) public mutating func append(_ newElement: Element) {
         self.storage.append(newElement)
     }
     
     @inlinable
-    mutating func append(contentsOf newElements: some Sequence<Element>){
+    @_spi(IntegrationTests) public mutating func append(contentsOf newElements: some Sequence<Element>){
         self.storage.append(contentsOf: newElements)
     }
     
     @discardableResult
     @inlinable
-    mutating func remove(at index: Int) -> Element {
+    @_spi(IntegrationTests) public mutating func remove(at index: Int) -> Element {
         self.storage.remove(at: index)
     }
     
     @inlinable
-    mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+    @_spi(IntegrationTests) public mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
         try self.storage.removeAll(where: shouldBeRemoved)
     }
     
     @inlinable
-    mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+    @_spi(IntegrationTests) public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
         try self.storage.sort(by: areInIncreasingOrder)
     }
 }

--- a/Sources/X509/TinyArray.swift
+++ b/Sources/X509/TinyArray.swift
@@ -224,30 +224,25 @@ extension TinyArray.Storage {
             
         case .arbitrary(var elements):
             if elements.isEmpty {
-                if let array = newElements as? Array<Element> {
-                    // fast path
-                    self = .arbitrary(array)
-                    
-                } else {
-                    // if `self` is currently empty and `newElements` just contains a single
-                    // element, we skip allocating an array and set `self` to `.one(firstElement)`
-                    var iterator = newElements.makeIterator()
-                    guard let firstElement = iterator.next() else {
-                        // newElements is empty, nothing to do
-                        return
-                    }
-                    guard let secondElement = iterator.next() else {
-                        // newElements just contains a single element
-                        // and we hit the fast path
-                        self = .one(firstElement)
-                        return
-                    }
-                    elements.reserveCapacity(elements.count + newElements.underestimatedCount)
-                    elements.append(firstElement)
-                    elements.append(secondElement)
-                    elements.appendRemainingElements(from: &iterator)
-                    self = .arbitrary(elements)
+                // if `self` is currently empty and `newElements` just contains a single
+                // element, we skip allocating an array and set `self` to `.one(firstElement)`
+                var iterator = newElements.makeIterator()
+                guard let firstElement = iterator.next() else {
+                    // newElements is empty, nothing to do
+                    return
                 }
+                guard let secondElement = iterator.next() else {
+                    // newElements just contains a single element
+                    // and we hit the fast path
+                    self = .one(firstElement)
+                    return
+                }
+                elements.reserveCapacity(elements.count + newElements.underestimatedCount)
+                elements.append(firstElement)
+                elements.append(secondElement)
+                elements.appendRemainingElements(from: &iterator)
+                self = .arbitrary(elements)
+            
             } else {
                 elements.append(contentsOf: newElements)
                 self = .arbitrary(elements)

--- a/Sources/_CertificateInternals/CMakeLists.txt
+++ b/Sources/_CertificateInternals/CMakeLists.txt
@@ -12,5 +12,12 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_subdirectory(X509)
-add_subdirectory(_CertificateInternals)
+add_library(_CertificateInternals
+  "_TinyArray.swift")
+
+target_link_libraries(X509 PUBLIC)
+set_target_properties(_CertificateInternals PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+_install_target(_CertificateInternals)
+set_property(GLOBAL APPEND PROPERTY SWIFT_CERTIFICATES_EXPORTS _TinyArray)

--- a/Sources/_CertificateInternals/CMakeLists.txt
+++ b/Sources/_CertificateInternals/CMakeLists.txt
@@ -15,9 +15,8 @@
 add_library(_CertificateInternals
   "_TinyArray.swift")
 
-target_link_libraries(X509 PUBLIC)
 set_target_properties(_CertificateInternals PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 
 _install_target(_CertificateInternals)
-set_property(GLOBAL APPEND PROPERTY SWIFT_CERTIFICATES_EXPORTS _TinyArray)
+set_property(GLOBAL APPEND PROPERTY SWIFT_CERTIFICATES_EXPORTS _CertificateInternals)

--- a/Sources/_CertificateInternals/_TinyArray.swift
+++ b/Sources/_CertificateInternals/_TinyArray.swift
@@ -17,7 +17,7 @@ import Foundation
 /// ``TinyArray`` is a ``RandomAccessCollection`` optimised to store zero or one ``Element``.
 /// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate separate storage on the heap
 /// and instead stores the ``Element`` inline.
-@_spi(IntegrationTests) public struct TinyArray<Element> {
+public struct _TinyArray<Element> {
     @usableFromInline
     enum Storage {
         case one(Element)
@@ -30,79 +30,79 @@ import Foundation
 
 // MARK: - TinyArray "public" interface
 
-extension TinyArray: Equatable where Element: Equatable {}
-extension TinyArray: Hashable where Element: Hashable {}
-extension TinyArray: Sendable where Element: Sendable {}
+extension _TinyArray: Equatable where Element: Equatable {}
+extension _TinyArray: Hashable where Element: Hashable {}
+extension _TinyArray: Sendable where Element: Sendable {}
 
-extension TinyArray: RandomAccessCollection {
-    @_spi(IntegrationTests) public typealias Element = Element
+extension _TinyArray: RandomAccessCollection {
+    public typealias Element = Element
     
-    @_spi(IntegrationTests) public typealias Index = Int
+    public typealias Index = Int
     
     @inlinable
-    @_spi(IntegrationTests) public subscript(position: Int) -> Element {
+    public subscript(position: Int) -> Element {
         get {
             self.storage[position]
         }
     }
     
     @inlinable
-    @_spi(IntegrationTests) public var startIndex: Int {
+    public var startIndex: Int {
         self.storage.startIndex
     }
     
     @inlinable
-    @_spi(IntegrationTests) public var endIndex: Int {
+    public var endIndex: Int {
         self.storage.endIndex
     }
 }
 
-extension TinyArray {
+extension _TinyArray {
     @inlinable
-    @_spi(IntegrationTests) public init(_ elements: some Sequence<Element>) {
+    public init(_ elements: some Sequence<Element>) {
         self.storage = .init(elements)
     }
     
     @inlinable
-    @_spi(IntegrationTests) public init(_ elements: some Sequence<Result<Element, some Error>>) throws {
+    public init(_ elements: some Sequence<Result<Element, some Error>>) throws {
         self.storage = try .init(elements)
     }
     
     @inlinable
-    @_spi(IntegrationTests) public init() {
+    public init() {
         self.storage = .init()
     }
     
     @inlinable
-    @_spi(IntegrationTests) public mutating func append(_ newElement: Element) {
+    public mutating func append(_ newElement: Element) {
         self.storage.append(newElement)
     }
     
     @inlinable
-    @_spi(IntegrationTests) public mutating func append(contentsOf newElements: some Sequence<Element>){
+    public mutating func append(contentsOf newElements: some Sequence<Element>){
         self.storage.append(contentsOf: newElements)
     }
     
     @discardableResult
     @inlinable
-    @_spi(IntegrationTests) public mutating func remove(at index: Int) -> Element {
+    public mutating func remove(at index: Int) -> Element {
         self.storage.remove(at: index)
     }
     
     @inlinable
-    @_spi(IntegrationTests) public mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
+    public mutating func removeAll(where shouldBeRemoved: (Element) throws -> Bool) rethrows {
         try self.storage.removeAll(where: shouldBeRemoved)
     }
     
     @inlinable
-    @_spi(IntegrationTests) public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
+    public mutating func sort(by areInIncreasingOrder: (Element, Element) throws -> Bool) rethrows {
         try self.storage.sort(by: areInIncreasingOrder)
     }
 }
 
 // MARK: - TinyArray.Storage "private" implementation
 
-extension TinyArray.Storage: Equatable where Element: Equatable {
+extension _TinyArray.Storage: Equatable where Element: Equatable {
     @inlinable
     static func ==(lhs: Self, rhs: Self) -> Bool {
         switch (lhs, rhs) {
@@ -123,7 +123,7 @@ extension TinyArray.Storage: Equatable where Element: Equatable {
         }
     }
 }
-extension TinyArray.Storage: Hashable where Element: Hashable {
+extension _TinyArray.Storage: Hashable where Element: Hashable {
     @inlinable
     func hash(into hasher: inout Hasher) {
         // same strategy as Array: https://github.com/apple/swift/blob/b42019005988b2d13398025883e285a81d323efa/stdlib/public/core/Array.swift#L1801
@@ -133,9 +133,9 @@ extension TinyArray.Storage: Hashable where Element: Hashable {
         }
     }
 }
-extension TinyArray.Storage: Sendable where Element: Sendable {}
+extension _TinyArray.Storage: Sendable where Element: Sendable {}
 
-extension TinyArray.Storage: RandomAccessCollection {
+extension _TinyArray.Storage: RandomAccessCollection {
     @inlinable
     subscript(position: Int) -> Element {
         get {
@@ -165,7 +165,7 @@ extension TinyArray.Storage: RandomAccessCollection {
     }
 }
  
-extension TinyArray.Storage {
+extension _TinyArray.Storage {
     @inlinable
     init(_ elements: some Sequence<Element>) {
         self = .arbitrary([])

--- a/Sources/_CertificateInternals/_TinyArray.swift
+++ b/Sources/_CertificateInternals/_TinyArray.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 /// ``TinyArray`` is a ``RandomAccessCollection`` optimised to store zero or one ``Element``.
 /// It supports arbitrary many elements but if only up to one ``Element`` is stored it does **not** allocate separate storage on the heap
 /// and instead stores the ``Element`` inline.

--- a/Tests/CertificateInternalsTests/TinyArrayTests.swift
+++ b/Tests/CertificateInternalsTests/TinyArrayTests.swift
@@ -13,20 +13,20 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@_spi(IntegrationTests) import X509
+import _CertificateInternals
 
 final class TinyArrayTests: XCTestCase {
     private func _assertEqual(
         _ expected: @autoclosure () -> some Sequence<Int>,
-        initial: @autoclosure () -> TinyArray<Int>,
-        _ mutate: (inout TinyArray<Int>) -> (),
+        initial: @autoclosure () -> _TinyArray<Int>,
+        _ mutate: (inout _TinyArray<Int>) -> (),
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
         var actual = initial()
         mutate(&actual)
         XCTAssertEqual(Array(actual), Array(expected()), file: file, line: line)
-        let expected = TinyArray(expected())
+        let expected = _TinyArray(expected())
         XCTAssertEqual(actual, expected, file: file, line: line)
         var acutalHasher = Hasher()
         acutalHasher.combine(actual)
@@ -37,8 +37,8 @@ final class TinyArrayTests: XCTestCase {
     
     private func assertEqual(
         _ expected: [Int],
-        initial: @autoclosure () -> TinyArray<Int> = TinyArray(),
-        _ mutate: (inout TinyArray<Int>) -> (),
+        initial: @autoclosure () -> _TinyArray<Int> = _TinyArray(),
+        _ mutate: (inout _TinyArray<Int>) -> (),
         file: StaticString = #filePath,
         line: UInt = #line
     ) {
@@ -48,17 +48,17 @@ final class TinyArrayTests: XCTestCase {
     }
     
     func testInit() {
-        XCTAssertEqual(Array(TinyArray([Int]())), [])
-        XCTAssertEqual(Array(TinyArray<Int>()), [])
-        XCTAssertEqual(TinyArray<Int>(), TinyArray<Int>([]))
+        XCTAssertEqual(Array(_TinyArray([Int]())), [])
+        XCTAssertEqual(Array(_TinyArray<Int>()), [])
+        XCTAssertEqual(_TinyArray<Int>(), _TinyArray<Int>([]))
         
-        XCTAssertEqual(Array(TinyArray<Int>(CollectionOfOne(1))), [1])
-        XCTAssertEqual(Array(TinyArray<Int>([1])), [1])
-        XCTAssertEqual(Array(TinyArray<Int>([1, 2])), [1, 2])
+        XCTAssertEqual(Array(_TinyArray<Int>(CollectionOfOne(1))), [1])
+        XCTAssertEqual(Array(_TinyArray<Int>([1])), [1])
+        XCTAssertEqual(Array(_TinyArray<Int>([1, 2])), [1, 2])
         
-        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3])), [1, 2, 3])
-        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3, 4])), [1, 2, 3, 4])
-        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5])
+        XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3])), [1, 2, 3])
+        XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4])), [1, 2, 3, 4])
+        XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5])
     }
     
     func testAppend() {
@@ -279,27 +279,27 @@ final class TinyArrayTests: XCTestCase {
     }
     
     func testThrowingInitFromResult() {
-        XCTAssertEqual(Array(try TinyArray<Int>(CollectionOfOne(Result<_, Error>.success(1)))), [1])
-        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1)])), [1])
-        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2)])), [1, 2])
-        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3)])), [1, 2, 3])
-        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4)])), [1, 2, 3, 4])
-        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4), .success(5)])), [1, 2, 3, 4, 5])
+        XCTAssertEqual(Array(try _TinyArray<Int>(CollectionOfOne(Result<_, Error>.success(1)))), [1])
+        XCTAssertEqual(Array(try _TinyArray([Result<_, Error>.success(1)])), [1])
+        XCTAssertEqual(Array(try _TinyArray([Result<_, Error>.success(1), .success(2)])), [1, 2])
+        XCTAssertEqual(Array(try _TinyArray([Result<_, Error>.success(1), .success(2), .success(3)])), [1, 2, 3])
+        XCTAssertEqual(Array(try _TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4)])), [1, 2, 3, 4])
+        XCTAssertEqual(Array(try _TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4), .success(5)])), [1, 2, 3, 4, 5])
         
         struct MyError: Error {}
         
-        XCTAssertThrowsError(Array(try TinyArray<Int>([Result.failure(MyError())])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([Result.failure(MyError()), Result.failure(MyError())])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), Result.failure(MyError())])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), Result.failure(MyError()), .success(2)])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), Result.failure(MyError())])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), Result.failure(MyError()), .success(4)])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), .success(3), Result.failure(MyError())])))
-        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), .success(3), .success(4), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([Result.failure(MyError()), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), Result.failure(MyError()), .success(2)])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), .success(2), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), .success(2), Result.failure(MyError()), .success(4)])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), .success(2), .success(3), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try _TinyArray<Int>([.success(1), .success(2), .success(3), .success(4), Result.failure(MyError())])))
     }
 }
 
-extension TinyArray: ExpressibleByArrayLiteral {
+extension _TinyArray: ExpressibleByArrayLiteral {
     public typealias ArrayLiteralElement = Element
     
     public init(arrayLiteral elements: Element...) {

--- a/Tests/X509Tests/TinyArrayTests.swift
+++ b/Tests/X509Tests/TinyArrayTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
-@testable import X509
+@_spi(IntegrationTests) import X509
 
 final class TinyArrayTests: XCTestCase {
     private func _assertEqual(

--- a/Tests/X509Tests/TinyArrayTests.swift
+++ b/Tests/X509Tests/TinyArrayTests.swift
@@ -1,0 +1,308 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+@testable import X509
+
+final class TinyArrayTests: XCTestCase {
+    private func _assertEqual(
+        _ expected: @autoclosure () -> some Sequence<Int>,
+        initial: @autoclosure () -> TinyArray<Int>,
+        _ mutate: (inout TinyArray<Int>) -> (),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        var actual = initial()
+        mutate(&actual)
+        XCTAssertEqual(Array(actual), Array(expected()), file: file, line: line)
+        let expected = TinyArray(expected())
+        XCTAssertEqual(actual, expected, file: file, line: line)
+        var acutalHasher = Hasher()
+        acutalHasher.combine(actual)
+        var expectedHasher = Hasher()
+        expectedHasher.combine(expected)
+        XCTAssertEqual(acutalHasher.finalize(), expectedHasher.finalize(), "\(actual) does not have the same hash as \(expected)", file: file, line: line)
+    }
+    
+    private func assertEqual(
+        _ expected: [Int],
+        initial: @autoclosure () -> TinyArray<Int> = TinyArray(),
+        _ mutate: (inout TinyArray<Int>) -> (),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        _assertEqual(expected, initial: initial(), mutate, file: file, line: line)
+        // get a sequence that is not an `Array` to hit the slow path as well
+        _assertEqual(expected.lazy.map { $0 }, initial: initial(), mutate, file: file, line: line)
+    }
+    
+    func testInit() {
+        XCTAssertEqual(Array(TinyArray([Int]())), [])
+        XCTAssertEqual(Array(TinyArray<Int>()), [])
+        XCTAssertEqual(TinyArray<Int>(), TinyArray<Int>([]))
+        
+        XCTAssertEqual(Array(TinyArray<Int>(CollectionOfOne(1))), [1])
+        XCTAssertEqual(Array(TinyArray<Int>([1])), [1])
+        XCTAssertEqual(Array(TinyArray<Int>([1, 2])), [1, 2])
+        
+        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3])), [1, 2, 3])
+        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3, 4])), [1, 2, 3, 4])
+        XCTAssertEqual(Array(TinyArray<Int>([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5])
+    }
+    
+    func testAppend() {
+        assertEqual([1]) { array in
+            array.append(1)
+        }
+        assertEqual([1, 2]) { array in
+            array.append(1)
+            array.append(2)
+        }
+        assertEqual([1, 2, 3]) { array in
+            array.append(1)
+            array.append(2)
+            array.append(3)
+        }
+        assertEqual([1, 2, 3, 4]) { array in
+            array.append(1)
+            array.append(2)
+            array.append(3)
+            array.append(4)
+        }
+    }
+    
+    func testAppendContentsOf() {
+        assertEqual([]) { array in
+            array.append(contentsOf: [])
+        }
+        assertEqual([]) { array in
+            array.append(contentsOf: [])
+            array.append(contentsOf: [])
+        }
+        assertEqual([1]) { array in
+            array.append(contentsOf: [1])
+        }
+        assertEqual([1]) { array in
+            array.append(contentsOf: [1])
+            array.append(contentsOf: [])
+        }
+        assertEqual([1, 2]) { array in
+            array.append(contentsOf: [1, 2])
+        }
+        assertEqual([1, 2]) { array in
+            array.append(contentsOf: [1, 2])
+            array.append(contentsOf: [])
+        }
+        assertEqual([1, 2, 3]) { array in
+            array.append(contentsOf: [1, 2, 3])
+        }
+        assertEqual([1, 2, 3, 4]) { array in
+            array.append(contentsOf: [1, 2, 3, 4])
+        }
+        assertEqual([1, 2, 3, 4, 5]) { array in
+            array.append(contentsOf: [1, 2, 3, 4, 5])
+        }
+        
+        assertEqual([1, 2]) { array in
+            array.append(contentsOf: [1])
+            array.append(contentsOf: [2])
+        }
+        assertEqual([1, 2, 3]) { array in
+            array.append(contentsOf: [1])
+            array.append(contentsOf: [2, 3])
+        }
+        assertEqual([1, 2, 3]) { array in
+            array.append(contentsOf: [1, 2])
+            array.append(contentsOf: [3])
+        }
+        assertEqual([1, 2, 3, 4]) { array in
+            array.append(contentsOf: [1, 2])
+            array.append(contentsOf: [3, 4])
+        }
+        assertEqual([1, 2, 3, 4]) { array in
+            array.append(contentsOf: [1])
+            array.append(contentsOf: [2, 3, 4])
+        }
+        assertEqual([1, 2, 3, 4]) { array in
+            array.append(contentsOf: [1, 2, 3])
+            array.append(contentsOf: [4])
+        }
+        assertEqual([1, 2, 3, 4, 5]) { array in
+            array.append(contentsOf: [1, 2, 3, 4])
+            array.append(contentsOf: [5])
+        }
+        assertEqual([1, 2, 3, 4, 5]) { array in
+            array.append(contentsOf: [1, 2, 3])
+            array.append(contentsOf: [4, 5])
+        }
+        assertEqual([1, 2, 3, 4, 5]) { array in
+            array.append(contentsOf: [1, 2])
+            array.append(contentsOf: [3, 4, 5])
+        }
+        assertEqual([1, 2, 3, 4, 5]) { array in
+            array.append(contentsOf: [1])
+            array.append(contentsOf: [2, 3, 4, 5])
+        }
+    }
+    
+    func testRemoveAt() {
+        assertEqual([], initial: [1]) { array in
+            array.remove(at: 0)
+        }
+        assertEqual([1], initial: [1, 2]) { array in
+            array.remove(at: 1)
+        }
+        assertEqual([2], initial: [1, 2]) { array in
+            array.remove(at: 0)
+        }
+        assertEqual([], initial: [1, 2]) { array in
+            array.remove(at: 1)
+            array.remove(at: 0)
+        }
+        assertEqual([], initial: [1, 2]) { array in
+            array.remove(at: 0)
+            array.remove(at: 0)
+        }
+        assertEqual([1, 2], initial: [1, 2, 3]) { array in
+            array.remove(at: 2)
+        }
+        assertEqual([1, 3], initial: [1, 2, 3]) { array in
+            array.remove(at: 1)
+        }
+        assertEqual([2, 3], initial: [1, 2, 3]) { array in
+            array.remove(at: 0)
+        }
+        assertEqual([1], initial: [1, 2, 3]) { array in
+            array.remove(at: 1)
+            array.remove(at: 1)
+        }
+        assertEqual([2], initial: [1, 2, 3]) { array in
+            array.remove(at: 0)
+            array.remove(at: 1)
+        }
+        assertEqual([3], initial: [1, 2, 3]) { array in
+            array.remove(at: 1)
+            array.remove(at: 0)
+        }
+        assertEqual([], initial: [1, 2, 3]) { array in
+            array.remove(at: 2)
+            array.remove(at: 1)
+            array.remove(at: 0)
+        }
+        assertEqual([], initial: [1, 2, 3]) { array in
+            array.remove(at: 0)
+            array.remove(at: 0)
+            array.remove(at: 0)
+        }
+    }
+    
+    func testRemoveAll() {
+        assertEqual([], initial: []) { array in
+            array.removeAll(where: { _ in true })
+        }
+        assertEqual([], initial: [1]) { array in
+            array.removeAll(where: { _ in true })
+        }
+        assertEqual([], initial: [1, 2]) { array in
+            array.removeAll(where: { _ in true })
+        }
+        assertEqual([], initial: [1, 2, 3]) { array in
+            array.removeAll(where: { _ in true })
+        }
+        assertEqual([], initial: [1, 2, 3, 4]) { array in
+            array.removeAll(where: { _ in true })
+        }
+        assertEqual([], initial: [1, 2, 3, 4, 5]) { array in
+            array.removeAll(where: { _ in true })
+        }
+        
+        assertEqual([1], initial: [1]) { array in
+            array.removeAll(where: { _ in false })
+        }
+        assertEqual([1, 2], initial: [1, 2]) { array in
+            array.removeAll(where: { _ in false })
+        }
+        assertEqual([1, 2, 3], initial: [1, 2, 3]) { array in
+            array.removeAll(where: { _ in false })
+        }
+        assertEqual([1, 2, 3, 4], initial: [1, 2, 3, 4]) { array in
+            array.removeAll(where: { _ in false })
+        }
+        assertEqual([1, 2, 3, 4, 5], initial: [1, 2, 3, 4, 5]) { array in
+            array.removeAll(where: { _ in false })
+        }
+        
+        assertEqual([], initial: [1]) { array in
+            array.removeAll(where: { Set([1]).contains($0) })
+        }
+        assertEqual([2], initial: [1, 2]) { array in
+            array.removeAll(where: { Set([1]).contains($0) })
+        }
+        assertEqual([2, 3], initial: [1, 2, 3]) { array in
+            array.removeAll(where: { Set([1]).contains($0) })
+        }
+        assertEqual([2], initial: [1, 2, 3]) { array in
+            array.removeAll(where: { Set([1, 3]).contains($0) })
+        }
+    }
+    
+    func testSort() {
+        assertEqual([], initial: []) { array in
+            array.sort(by: { lhs, rhs in
+                XCTFail("should never be called")
+                return lhs < rhs
+            })
+        }
+        assertEqual([1], initial: [1]) { array in
+            array.sort(by: { lhs, rhs in
+                XCTFail("should never be called")
+                return lhs < rhs
+            })
+        }
+        assertEqual([2, 1], initial: [1, 2]) { array in
+            array.sort(by: >)
+        }
+        assertEqual([3, 2, 1], initial: [1, 2, 3]) { array in
+            array.sort(by: >)
+        }
+    }
+    
+    func testThrowingInitFromResult() {
+        XCTAssertEqual(Array(try TinyArray<Int>(CollectionOfOne(Result<_, Error>.success(1)))), [1])
+        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1)])), [1])
+        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2)])), [1, 2])
+        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3)])), [1, 2, 3])
+        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4)])), [1, 2, 3, 4])
+        XCTAssertEqual(Array(try TinyArray([Result<_, Error>.success(1), .success(2), .success(3), .success(4), .success(5)])), [1, 2, 3, 4, 5])
+        
+        struct MyError: Error {}
+        
+        XCTAssertThrowsError(Array(try TinyArray<Int>([Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([Result.failure(MyError()), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), Result.failure(MyError()), .success(2)])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), Result.failure(MyError()), .success(4)])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), .success(3), Result.failure(MyError())])))
+        XCTAssertThrowsError(Array(try TinyArray<Int>([.success(1), .success(2), .success(3), .success(4), Result.failure(MyError())])))
+    }
+}
+
+extension TinyArray: ExpressibleByArrayLiteral {
+    public typealias ArrayLiteralElement = Element
+    
+    public init(arrayLiteral elements: Element...) {
+        self.init(elements)
+    }
+}

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -13,7 +13,7 @@ services:
     image: swift-certificates:22.04-5.7
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -13,7 +13,7 @@ services:
     image: swift-certificates:22.04-5.7
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=9000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -13,7 +13,7 @@ services:
     image: swift-certificates:22.04-5.7
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -13,7 +13,8 @@ services:
     image: swift-certificates:22.04-5.7
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - MAX_ALLOCS_ALLOWED_empty_1=0
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:

--- a/docker/docker-compose.2204.57.yaml
+++ b/docker/docker-compose.2204.57.yaml
@@ -13,7 +13,7 @@ services:
     image: swift-certificates:22.04-5.7
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=9000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,8 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_empty_1=0
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.58.yaml
+++ b/docker/docker-compose.2204.58.yaml
@@ -14,7 +14,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,8 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_empty_1=0
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=9000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=3
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -13,7 +13,8 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_empty_1=0
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=1
+      - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 
   shell:

--- a/docker/docker-compose.2204.main.yaml
+++ b/docker/docker-compose.2204.main.yaml
@@ -13,7 +13,7 @@ services:
     environment:
       - WARN_AS_ERROR_ARG=-Xswiftc -warnings-as-errors
       - IMPORT_CHECK_ARG=--explicit-target-dependency-import-check error
-      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=10000
+      - MAX_ALLOCS_ALLOWED_tiny_array_cow_append_contents_of=9000
       - MAX_ALLOCS_ALLOWED_tiny_array_non_allocating_operations=0
       # - SANITIZER_ARG=--sanitize=thread # TSan broken still
 

--- a/scripts/update_cmakelists.sh
+++ b/scripts/update_cmakelists.sh
@@ -56,4 +56,5 @@ function update_cmakelists_source() {
 }
 
 update_cmakelists_source "X509" "*.swift"
+update_cmakelists_source "_CertificateInternals" "*.swift"
 


### PR DESCRIPTION
We want to improve allocations for a couple of collections that are only ever expected to store a single element. However, in rare cases they might store multiple elements so they still need to support that. 