### PR TITLE
Add support for Musl libc

### DIFF
--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -15,8 +15,11 @@
 import Foundation
 #if os(Windows)
 import WinSDK
-#elseif os(Linux) || os(Android)
+#elseif canImport(Glibc)
 import Glibc
+import CoreFoundation
+#elseif canImport(Musl)
+import Musl
 import CoreFoundation
 #elseif canImport(Darwin)
 import Darwin


### PR DESCRIPTION
Since Musl is sufficiently different from Glibc (see https://wiki.musl-libc.org/functional-differences-from-glibc.html), it requires a different import, which now should be applied to files that have `import Glibc` in them.