### PR TITLE
Add integer initialisers on `Certificate.SerialNumber`

### DIFF
--- a/Sources/X509/CertificateSerialNumber.swift
+++ b/Sources/X509/CertificateSerialNumber.swift
@@ -96,6 +96,7 @@ extension Certificate.SerialNumber: CustomStringConvertible {
     }
 }
 
+#if swift(>=5.8)
 @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
 extension Certificate.SerialNumber: ExpressibleByIntegerLiteral {
     /// Constructs a serial number from an integer.
@@ -114,6 +115,7 @@ extension Certificate.SerialNumber: ExpressibleByIntegerLiteral {
         self.bytes = ArraySlice(normalisingToASN1IntegerForm: bytes)
     }
 }
+#endif
 
 extension Array<UInt8> {
     @inlinable

--- a/Sources/X509/X509BaseTypes/ECDSASignature.swift
+++ b/Sources/X509/X509BaseTypes/ECDSASignature.swift
@@ -178,4 +178,14 @@ extension ArraySlice where Element == UInt8 {
         let realBytes = bigEndianRawInteger.drop(while: { $0 == 0 })
         self = ArraySlice(realBytes)
     }
+    
+    @inlinable
+    init(normalisingToASN1IntegerForm bigEndianRawInteger: ArraySlice<UInt8>) {
+        self = bigEndianRawInteger.drop(while: { $0 == 0 })
+    }
+    
+    @inlinable
+    init(normalisingToASN1IntegerForm bigEndianRawInteger: Array<UInt8>) {
+        self.init(normalisingToASN1IntegerForm: bigEndianRawInteger[...])
+    }
 }

--- a/Sources/X509/X509BaseTypes/ECDSASignature.swift
+++ b/Sources/X509/X509BaseTypes/ECDSASignature.swift
@@ -174,7 +174,7 @@ extension ArraySlice where Element == UInt8 {
     ///
     /// This means we strip leading zero bytes.
     @inlinable
-    init<Bytes: RandomAccessCollection>(normalisingToASN1IntegerForm bigEndianRawInteger: Bytes) where Bytes.Element == UInt8 {
+    init<Bytes: Collection>(normalisingToASN1IntegerForm bigEndianRawInteger: Bytes) where Bytes.Element == UInt8 {
         let realBytes = bigEndianRawInteger.drop(while: { $0 == 0 })
         self = ArraySlice(realBytes)
     }

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -25,10 +25,9 @@ final class CertificateTests: XCTestCase {
         XCTAssertEqual(s, "a:14:1e:28")
     }
     
+    #if swift(>=5.8)
     @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
-    func testSerialNumber() {
-        XCTAssertEqual(Certificate.SerialNumber(123456789), 123456789)
-        
+    func testSerialNumberStaticBigInt() {
         XCTAssertEqual(
             (
                 0b0000_0001__0000_0010__0000_0011__0000_0100__0000_0101__0000_0110__0000_0111__0000_1000__0000_1001__0000_1010__0000_1011__0000_1100__0000_1101__0000_1110 as Certificate.SerialNumber
@@ -42,9 +41,12 @@ final class CertificateTests: XCTestCase {
             ).bytes,
             [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
         )
-        
+        XCTAssertEqual(Certificate.SerialNumber(123456789), 123456789)
+    }
+    #endif
+    
+    func testSerialNumberInits() {
         XCTAssertEqual(Certificate.SerialNumber(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8]).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
-        
         XCTAssertEqual(Certificate.SerialNumber(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8][...]).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
         XCTAssertEqual(Certificate.SerialNumber(bytes: AnyCollection([0, 1, 2, 3, 4, 5, 6, 7, 8])).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
     }

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -24,6 +24,30 @@ final class CertificateTests: XCTestCase {
         let s = String(describing: serial)
         XCTAssertEqual(s, "a:14:1e:28")
     }
+    
+    @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, *)
+    func testSerialNumber() {
+        XCTAssertEqual(Certificate.SerialNumber(123456789), 123456789)
+        
+        XCTAssertEqual(
+            (
+                0b0000_0001__0000_0010__0000_0011__0000_0100__0000_0101__0000_0110__0000_0111__0000_1000__0000_1001__0000_1010__0000_1011__0000_1100__0000_1101__0000_1110 as Certificate.SerialNumber
+            ).bytes,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14]
+        )
+        
+        XCTAssertEqual(
+            (
+                0x00_01_02_03_04_05_06_07_08_09_0A_0B_0C_0D_0E_0F_10_11_12_13_14 as Certificate.SerialNumber
+            ).bytes,
+            [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+        )
+        
+        XCTAssertEqual(Certificate.SerialNumber(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8]).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
+        
+        XCTAssertEqual(Certificate.SerialNumber(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8][...]).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
+        XCTAssertEqual(Certificate.SerialNumber(bytes: AnyCollection([0, 1, 2, 3, 4, 5, 6, 7, 8])).bytes, [1, 2, 3, 4, 5, 6, 7, 8])
+    }
 
     func testPrintingVersions() {
         XCTAssertEqual(String(describing: Certificate.Version.v1), "X509v1")


### PR DESCRIPTION
`Certificate.SerialNumber` can now be constructed from `FixedWidthInteger` and `StaticBigInt`