### PR TITLE
Allow `OCSPRequester` to fail `OCSPVerifierPolicy`

### DIFF
--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -62,11 +62,11 @@ extension OCSPRequesterQueryResult {
     /// The OCSP query is considered unsuccessful but will **not** fail verification, neither in ``OCSPFailureMode/soft`` nor in ``OCSPFailureMode/hard`` failure mode.
     /// The certificate is then considered to meet the ``OCSPVerifierPolicy``.
     /// - Parameter reason: the reason why the OCSP query failed which may be used for diagnostics
+    /// - warning: The ``OCSPVerifierPolicy`` will assume that verification has succeeded and therefore pass OCSP verification for the given certificate.
     @inlinable
     public static func nonTerminalError(_ reason: Error) -> Self {
         .init(.nonTerminal(reason))
     }
-    
     
     /// The OCSP query is considered unsuccessful and will fail verification in both ``OCSPFailureMode/soft`` and ``OCSPFailureMode/hard`` failure mode.
     /// The certificate is then considered to not meet the ``OCSPVerifierPolicy`` and ``OCSPVerifierPolicy/chainMeetsPolicyRequirements(chain:)`` will return ``PolicyEvaluationResult/failsToMeetPolicy(reason:)`` with the given ``reason``.

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -59,7 +59,6 @@ extension OCSPRequesterQueryResult {
         .init(.success(bytes))
     }
     
-    
     /// The OCSP query is considered unsuccessful but will **not** fail verification, neither in ``OCSPFailureMode/soft`` nor in ``OCSPFailureMode/hard`` failure mode.
     /// The certificate is then considered to meet the ``OCSPVerifierPolicy``.
     /// - Parameter reason: the reason why the OCSP query failed which may be used for diagnostics

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -23,13 +23,18 @@ import Foundation
 #endif
 
 actor TestRequester: OCSPRequester {
-    private let queryClosure: @Sendable (OCSPRequest, String) async throws -> OCSPResponse
+    enum QueryResult {
+        case success(OCSPResponse)
+        case softFailure(Error)
+        case hardFailure(Error)
+    }
+    private let queryClosure: @Sendable (OCSPRequest, String) async -> QueryResult
     private let file: StaticString
     private let line: UInt
     var queryCount: Int = 0
     
     init(
-        query: @escaping @Sendable (OCSPRequest, String) async throws -> OCSPResponse,
+        query: @escaping @Sendable (OCSPRequest, String) async -> QueryResult,
         file: StaticString = #file,
         line: UInt = #line
     ) {
@@ -38,23 +43,29 @@ actor TestRequester: OCSPRequester {
         self.line = line
     }
     
-    func query(request requestDerEncoded: [UInt8], uri: String) async throws -> [UInt8] {
+    func query(request requestDerEncoded: [UInt8], uri: String) async -> OCSPRequesterQueryResult {
         queryCount += 1
         let request: OCSPRequest
         do {
             request = try OCSPRequest(derEncoded: requestDerEncoded[...])
         } catch {
             XCTFail("failed to deserialise request \(error)", file: file, line: line)
-            throw error
+            return .hardFailure(reason: error)
         }
-        let response = try await queryClosure(request, uri)
-        do {
-            var serializer = DER.Serializer()
-            try serializer.serialize(response)
-            return serializer.serializedBytes
-        } catch {
-            XCTFail("failed to serialise response \(error)", file: file, line: line)
-            throw error
+        switch await queryClosure(request, uri) {
+        case .success(let response):
+            do {
+                var serializer = DER.Serializer()
+                try serializer.serialize(response)
+                return .response(serializer.serializedBytes)
+            } catch {
+                XCTFail("failed to serialise response \(error)", file: file, line: line)
+                return .hardFailure(reason: error)
+            }
+        case .softFailure(let error):
+            return .softFailure(reason: error)
+        case .hardFailure(let error):
+            return .hardFailure(reason: error)
         }
     }
 }
@@ -75,7 +86,13 @@ extension OCSPRequester where Self == TestRequester {
         file: StaticString = #file,
         line: UInt = #line
     ) -> some OCSPRequester {
-        TestRequester(query: query).assertNoThrow(file: file, line: line)
+        TestRequester(query: { request, url in
+            do {
+                return .success(try await query(request, url))
+            } catch {
+                return .hardFailure(error)
+            }
+        }).assertNoThrow(file: file, line: line)
     }
 }
 
@@ -83,13 +100,20 @@ struct AssertNoThrowRequester<Wrapped: OCSPRequester>: OCSPRequester {
     var wrapped: Wrapped
     var file: StaticString
     var line: UInt
-    func query(request: [UInt8], uri: String) async throws -> [UInt8] {
-        do {
-            return try await wrapped.query(request: request, uri: uri)
-        } catch {
-            XCTFail("test query closure throw error \(error)", file: file, line: line)
-            throw error
+    func query(request: [UInt8], uri: String) async -> OCSPRequesterQueryResult {
+        switch await wrapped.query(request: request, uri: uri).storage {
+        case .success(let bytes):
+            return .response(bytes)
+        case .softFailure(let error):
+            XCTFail("test query closure throw soft failure \(error)", file: file, line: line)
+            return .softFailure(reason: error)
+        case .hardFailure(let error):
+            XCTFail("test query closure throw hard failure \(error)", file: file, line: line)
+            return .hardFailure(reason: error)
         }
+        
+            
+        
     }
 }
 
@@ -552,14 +576,26 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         )
     }
     
-    func testQueryIsAllowedToFail() async {
+    func testDoesNotFailOnSoftFailure() async {
         await self.assertChain(
             soft: .meetsPolicy,
             hard: .meetsPolicy,
             chain: Self.chainWithSingleCertWithOCSP,
-            requester: TestRequester { request, uri -> OCSPResponse in
+            requester: TestRequester { request, uri -> TestRequester.QueryResult in
                 struct QueryErrorsAreAcceptable: Error {}
-                throw QueryErrorsAreAcceptable()
+                return .softFailure(QueryErrorsAreAcceptable())
+            }
+        )
+    }
+    
+    func testFailsOnHardError() async {
+        await self.assertChain(
+            soft: .failsToMeetPolicy,
+            hard: .failsToMeetPolicy,
+            chain: Self.chainWithSingleCertWithOCSP,
+            requester: TestRequester { request, uri -> TestRequester.QueryResult in
+                struct QueryErrorsAreAcceptable: Error {}
+                return .hardFailure(QueryErrorsAreAcceptable())
             }
         )
     }
@@ -676,15 +712,19 @@ final class OCSPVerifierPolicyTests: XCTestCase {
                 self.responses = responses
             }
             var nextIndex: Int = 0
-            func query(request: [UInt8], uri: String) async throws -> [UInt8] {
+            func query(request: [UInt8], uri: String) async -> OCSPRequesterQueryResult {
                 let responseIndex = nextIndex
                 nextIndex += 1
                 guard responses.indices.contains(responseIndex) else {
                     struct StaticOCSPRequesterRunOutOfResponses: Error {}
-                    throw StaticOCSPRequesterRunOutOfResponses()
+                    return .hardFailure(reason: StaticOCSPRequesterRunOutOfResponses())
                 }
                 let response = responses[responseIndex]
-                return try DER.Serializer.serialized(element: response)
+                do {
+                    return .response(try DER.Serializer.serialized(element: response))
+                } catch {
+                    return .hardFailure(reason: error)
+                }
             }
         }
         


### PR DESCRIPTION
### Motivation
A concrete `OCSPRequester` might want to decided that a request failure is fatal and therefore fail the OCSP verification.

### Modifications
Instead of throwing let the query method return a more descriptor return value that can disambiguate between terminal and non-terminal errors.

### Results
`OCSPRequester` can now result in a verification failure