### PR TITLE
Remove unused import

### DIFF
--- a/Sources/X509/Signature.swift
+++ b/Sources/X509/Signature.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftASN1
-@preconcurrency import Crypto
 @preconcurrency import _CryptoExtras
 import Foundation
 


### PR DESCRIPTION
We only use symbols from `_CryptoExtras` in this file.
This silences the `@preconcurrency import` warning.