### PR TITLE
Reject `v1` `Certificate`s with extensions

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(X509
   "Verifier/RFC5280/NameConstraintsPolicy.swift"
   "Verifier/RFC5280/RFC5280Policy.swift"
   "Verifier/RFC5280/URIConstraints.swift"
+  "Verifier/RFC5280/VersionPolicy.swift"
   "Verifier/UnverifiedChain.swift"
   "Verifier/VerificationDiagnostic.swift"
   "Verifier/Verifier.swift"

--- a/Sources/X509/Verifier/RFC5280/VersionPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/VersionPolicy.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftASN1
+
+/// A sub-policy of the ``RFC5280Policy`` that polices that version 1 certificates do not contain extensions.
+@usableFromInline
+struct VersionPolicy: VerifierPolicy {
+    @inlinable
+    var verifyingCriticalExtensions: [SwiftASN1.ASN1ObjectIdentifier] { [] }
+    
+    @inlinable
+    init() {}
+    
+    @inlinable
+    func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        for certificate in chain {
+            if certificate.version == .v1 && certificate.extensions.isEmpty == false {
+                return .failsToMeetPolicy(reason: "version 1 certificate contains extensions but should not: \(certificate)")
+            }
+        }
+        return .meetsPolicy
+    }
+}

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -262,6 +262,38 @@ final class RFC5280PolicyTests1: RFC5280PolicyBase {
 
         XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
     }
+    
+    func testValidV1CertsAreAccepted() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(version: .v1, issuer: .unconstrainedIntermediate, customExtensions: .init())
+
+        var verifier = Verifier(rootCertificates: roots) { RFC5280Policy(validationTime: Date()) }
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, TestPKI.unconstrainedIntermediate, TestPKI.unconstrainedCA])
+    }
+    
+    func testValidV1CertsWithExtensionsAreRejected() async throws {
+        let roots = CertificateStore([TestPKI.unconstrainedCA])
+        let leaf = TestPKI.issueLeaf(version: .v1, issuer: .unconstrainedIntermediate, customExtensions: try .init {
+            Certificate.Extension(oid: [1, 2, 3, 4], critical: false, value: [5, 6, 7, 8])
+        })
+
+        var verifier = Verifier(rootCertificates: roots) { RFC5280Policy(validationTime: Date()) }
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([TestPKI.unconstrainedIntermediate]))
+
+        guard case .couldNotValidate(let policyFailures) = result else {
+            XCTFail("Validated: \(result)")
+            return
+        }
+         
+        XCTAssertEqual(policyFailures.count, 1)
+    }
 
     private func _expiredLeafIsRejected(_ policyFactory: PolicyFactory) async throws {
         let roots = CertificateStore([TestPKI.unconstrainedCA])
@@ -1572,6 +1604,7 @@ fileprivate enum TestPKI {
     }
 
     static func issueLeaf(
+        version: Certificate.Version = .v3,
         commonName: String = "Leaf",
         notValidBefore: Date = Self.startDate,
         notValidAfter: Date = Self.startDate + .days(365),
@@ -1601,7 +1634,7 @@ fileprivate enum TestPKI {
         }
 
         return try! Certificate(
-            version: .v3,
+            version: version,
             serialNumber: .init(),
             publicKey: .init(leafKey.publicKey),
             notValidBefore: notValidBefore,


### PR DESCRIPTION
v1 certificates do not support extensions and any v1 certificate we encounter with extensions can’t be used to verify a chain.