### PR TITLE
Do not count self-issued certificates against maxPathLength

### DIFF
--- a/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
@@ -86,8 +86,30 @@ struct BasicConstraintsPolicy: VerifierPolicy {
             } catch {
                 return .failsToMeetPolicy(reason: "RFC5280Policy: Error processing basic constraints for \(cert): \(error)")
             }
-
-            subCACount += 1
+            
+            if cert.issuer != cert.subject {
+                // only non-self-issued certificates count against the maxPathLength limit
+                //
+                // RFC Section 4.2.1.9.  Basic Constraints
+                // [...]
+                // The pathLenConstraint field is meaningful only if the cA boolean is
+                // asserted and the key usage extension, if present, asserts the
+                // keyCertSign bit (Section 4.2.1.3).  In this case, it gives the
+                // maximum number of non-self-issued intermediate certificates that may
+                // follow this certificate in a valid certification path.  (Note: The
+                // last certificate in the certification path is not an intermediate
+                // certificate, and is not included in this limit.  Usually, the last
+                // certificate is an end entity certificate, but it can be a CA
+                // certificate.)  A pathLenConstraint of zero indicates that no non-
+                // self-issued intermediate CA certificates may follow in a valid
+                // certification path.  Where it appears, the pathLenConstraint field
+                // MUST be greater than or equal to zero.  Where pathLenConstraint does
+                // not appear, no limit is imposed.
+                // [...]
+                // https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9
+                
+                subCACount += 1
+            }
         }
 
         return .meetsPolicy

--- a/Tests/X509Tests/RFC5280PolicyTests.swift
+++ b/Tests/X509Tests/RFC5280PolicyTests.swift
@@ -907,6 +907,55 @@ final class RFC5280PolicyTests1: RFC5280PolicyBase {
     func testPathLengthConstraintsOnRootsAreAppliedBasePolicy() async throws {
         try await self._pathLengthConstraintsFromIntermediatesAreApplied(.basicConstraints)
     }
+    
+    func _pathLengthConstraintsDoesOnlyCountNonSelfIssuedCertificates(_ policyFactory: PolicyFactory) async throws {
+        // We are building a certificate chain that looks like this:
+        // Cert(Iss=Y, Sub=X, Key=1, pathLen=0)
+        // Cert(Iss=X, Sub=X, Key=2) // self issued with different public key
+        // Cert(Iss=X, Sub=Z, Key=3)
+        
+        
+        let alternativeRoot = TestPKI.issueCA(
+            extensions: try Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+            }
+        )
+        
+        let intermediate = TestPKI.issueIntermediate(
+            name: alternativeRoot.subject,
+            key: .init(TestPKI.unconstrainedIntermediateKey.publicKey),
+            extensions: try .init {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: 0)
+                )
+            },
+            issuer: .unconstrainedRoot
+        )
+
+        let leaf = TestPKI.issueLeaf(issuer: .init(name: alternativeRoot.subject, key: .init(TestPKI.unconstrainedIntermediateKey)))
+
+        var verifier = Verifier(rootCertificates: CertificateStore([alternativeRoot])) {
+            policyFactory.create(TestPKI.startDate + 2.5)
+        }
+        let result = await verifier.validate(leafCertificate: leaf, intermediates: CertificateStore([intermediate]))
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Unable to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(chain, [leaf, intermediate, alternativeRoot])
+    }
+    
+    func testPathLengthConstraintsDoesOnlyCountNonSelfIssuedCertificates() async throws {
+        try await self._pathLengthConstraintsDoesOnlyCountNonSelfIssuedCertificates(.rfc5280)
+    }
+
+    func testPathLengthConstraintsDoesOnlyCountNonSelfIssuedCertificatesBasePolicy() async throws {
+        try await self._pathLengthConstraintsDoesOnlyCountNonSelfIssuedCertificates(.basicConstraints)
+    }
 
     func testDNSNameConstraintsExcludedSubtrees() async throws {
         for (dnsName, constraint, match) in DNSNamesTests.fixtures {
@@ -1543,32 +1592,13 @@ fileprivate enum TestPKI {
         CommonName("Swift Certificate Test Intermediate 2")
     }
 
-    enum Issuer {
-        case unconstrainedRoot
-        case unconstrainedIntermediate
-        case secondLevelIntermediate
-
-        var name: DistinguishedName {
-            switch self {
-            case .unconstrainedRoot:
-                return unconstrainedCAName
-            case .unconstrainedIntermediate:
-                return unconstrainedIntermediateName
-            case .secondLevelIntermediate:
-                return secondLevelIntermediateName
-            }
-        }
-
-        var key: Certificate.PrivateKey {
-            switch self {
-            case .unconstrainedRoot:
-                return .init(unconstrainedCAPrivateKey)
-            case .unconstrainedIntermediate:
-                return .init(unconstrainedIntermediateKey)
-            case .secondLevelIntermediate:
-                return .init(secondLevelIntermediateKey)
-            }
-        }
+    struct Issuer {
+        static let unconstrainedRoot = Self(name: TestPKI.unconstrainedCAName, key: .init(TestPKI.unconstrainedCAPrivateKey))
+        static let unconstrainedIntermediate = Self(name: TestPKI.unconstrainedIntermediateName, key: .init(TestPKI.unconstrainedIntermediateKey))
+        static let secondLevelIntermediate = Self(name: TestPKI.secondLevelIntermediateName, key: .init(TestPKI.secondLevelIntermediateKey))
+        
+        var name: DistinguishedName
+        var key: Certificate.PrivateKey
     }
 
     static func issueLeaf(


### PR DESCRIPTION
Only non-self-issued certificates count against the maxPathLength limit.

RFC Section 4.2.1.9.  Basic Constraints:

> The pathLenConstraint field is meaningful only if the cA boolean is
> asserted and the key usage extension, if present, asserts the
> keyCertSign bit (Section 4.2.1.3).  In this case, it gives the
> maximum number of non-self-issued intermediate certificates that may
> follow this certificate in a valid certification path.  (Note: The
> last certificate in the certification path is not an intermediate
> certificate, and is not included in this limit.  Usually, the last
> certificate is an end entity certificate, but it can be a CA
> certificate.)  A pathLenConstraint of zero indicates that no non-
> self-issued intermediate CA certificates may follow in a valid
> certification path.  Where it appears, the pathLenConstraint field
> MUST be greater than or equal to zero.  Where pathLenConstraint does
> not appear, no limit is imposed.
> https://www.rfc-editor.org/rfc/rfc5280#section-4.2.1.9