### PR TITLE
Make `RelativeDistinguishedNameConvertible.makeRDN()` non-throwing

### DIFF
--- a/Sources/X509/DistinguishedNameBuilder/CommonName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/CommonName.swift
@@ -30,7 +30,7 @@ public struct CommonName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.commonName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/CountryName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/CountryName.swift
@@ -30,7 +30,7 @@ public struct CountryName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.countryName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/DNBuilder.swift
+++ b/Sources/X509/DistinguishedNameBuilder/DNBuilder.swift
@@ -33,8 +33,7 @@
 public struct DistinguishedNameBuilder {
     @inlinable
     public static func buildExpression<Extension: RelativeDistinguishedNameConvertible>(_ expression: Extension) -> DistinguishedName {
-        // TODO: Remove the try!
-        try! DistinguishedName([expression.makeRDN()])
+        DistinguishedName([expression.makeRDN()])
     }
 
     @inlinable
@@ -69,5 +68,5 @@ public struct DistinguishedNameBuilder {
 }
 
 public protocol RelativeDistinguishedNameConvertible {
-    func makeRDN() throws -> RelativeDistinguishedName
+    func makeRDN() -> RelativeDistinguishedName
 }

--- a/Sources/X509/DistinguishedNameBuilder/LocalityName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/LocalityName.swift
@@ -30,7 +30,7 @@ public struct LocalityName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.localityName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/OrganizationName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/OrganizationName.swift
@@ -30,7 +30,7 @@ public struct OrganizationName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.organizationName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/OrganizationalUnitName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/OrganizationalUnitName.swift
@@ -30,7 +30,7 @@ public struct OrganizationalUnitName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.organizationalUnitName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/StateOrProvinceName.swift
+++ b/Sources/X509/DistinguishedNameBuilder/StateOrProvinceName.swift
@@ -30,7 +30,7 @@ public struct StateOrProvinceName: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.stateOrProvinceName, utf8String: name)
         )

--- a/Sources/X509/DistinguishedNameBuilder/StreetAddress.swift
+++ b/Sources/X509/DistinguishedNameBuilder/StreetAddress.swift
@@ -30,7 +30,7 @@ public struct StreetAddress: RelativeDistinguishedNameConvertible {
     }
 
     @inlinable
-    public func makeRDN() throws -> RelativeDistinguishedName {
+    public func makeRDN() -> RelativeDistinguishedName {
         return RelativeDistinguishedName(
             .init(type: .RDNAttributeType.streetAddress, utf8String: name)
         )


### PR DESCRIPTION
`RelativeDistinguishedName` initialisation doesn’t actually throw and therefore `RelativeDistinguishedNameConvertible.makeRDN()` doesn’t need to be throwing either.