### PR TITLE
Fix preference of root certificates

### DIFF
--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -120,6 +120,9 @@ public struct Verifier<Policy: VerifierPolicy> {
                     )
                 )
 
+                // we need to reverse the order of the already sorted intermediates because
+                // we will push them on to the `partialChains` stack which in turn will
+                // consume them in the reverse order the have been pushed onto the stack
                 for parent in intermediateParents.reversed() {
                     if self.shouldSkipAddingCertificate(
                         partialChain: nextPartialCandidate,

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -122,7 +122,7 @@ public struct Verifier<Policy: VerifierPolicy> {
 
                 // we need to reverse the order of the already sorted intermediates because
                 // we will push them on to the `partialChains` stack which in turn will
-                // consume them in the reverse order the have been pushed onto the stack
+                // consume them in the reverse order that they have been pushed onto the stack
                 for parent in intermediateParents.reversed() {
                     if self.shouldSkipAddingCertificate(
                         partialChain: nextPartialCandidate,

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -120,7 +120,7 @@ public struct Verifier<Policy: VerifierPolicy> {
                     )
                 )
 
-                for parent in intermediateParents {
+                for parent in intermediateParents.reversed() {
                     if self.shouldSkipAddingCertificate(
                         partialChain: nextPartialCandidate,
                         nextCertificate: parent,
@@ -242,7 +242,7 @@ extension Array where Element == Certificate {
             return
         }
 
-        self.sort(by: { $0.issuerPreference(subjectAKI: aki) < $1.issuerPreference(subjectAKI: aki) })
+        self.sort(by: { $0.issuerPreference(subjectAKI: aki) > $1.issuerPreference(subjectAKI: aki) })
     }
 }
 

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -575,7 +575,7 @@ final class VerifierTests: XCTestCase {
         )
     }
 
-    func testRootsWithSPIArePreferred() async throws {
+    func testRootsWithSKIArePreferred() async throws {
         let roots = CertificateStore([Self.ca1WithoutSubjectKeyIdentifier, Self.ca1])
         let log = DiagnosticsLog()
 

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -574,7 +574,7 @@ final class VerifierTests: XCTestCase {
             ]
         )
     }
-    
+
     func testRootsWithSPIArePreferred() async throws {
         let roots = CertificateStore([Self.ca1WithoutSubjectKeyIdentifier, Self.ca1])
         let log = DiagnosticsLog()

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -49,6 +49,25 @@ final class VerifierTests: XCTestCase {
             issuerPrivateKey: .init(ca1PrivateKey)
         )
     }()
+    private static let ca1WithoutSubjectKeyIdentifier: Certificate = {
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(ca1PrivateKey.publicKey),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(3650),
+            issuer: ca1Name,
+            subject: ca1Name,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+                )
+                KeyUsage(keyCertSign: true)
+            },
+            issuerPrivateKey: .init(ca1PrivateKey)
+        )
+    }()
     private static let ca1CrossSignedByCA2: Certificate = {
         return try! Certificate(
             version: .v3,
@@ -555,6 +574,42 @@ final class VerifierTests: XCTestCase {
             ]
         )
     }
+    
+    func testRootsWithSPIArePreferred() async throws {
+        let roots = CertificateStore([Self.ca1WithoutSubjectKeyIdentifier, Self.ca1])
+        let log = DiagnosticsLog()
+
+        var verifier = Verifier(rootCertificates: roots) { Self.defaultPolicy }
+        let result = await verifier.validate(
+            leafCertificate: Self.localhostLeaf,
+            intermediates: CertificateStore([Self.intermediate1]),
+            diagnosticCallback: log.append(_:)
+        )
+
+        guard case .validCertificate(let chain) = result else {
+            XCTFail("Failed to validate: \(result)")
+            return
+        }
+
+        XCTAssertEqual(chain, [Self.localhostLeaf, Self.intermediate1, Self.ca1])
+
+        XCTAssertEqual(
+            log,
+            [
+                .searchingForIssuerOfPartialChain([Self.localhostLeaf]),
+                .foundCandidateIssuersOfPartialChainInIntermediateStore(
+                    [Self.localhostLeaf],
+                    issuers: [Self.intermediate1]
+                ),
+                .searchingForIssuerOfPartialChain([Self.localhostLeaf, Self.intermediate1]),
+                .foundCandidateIssuersOfPartialChainInRootStore(
+                    [Self.localhostLeaf, Self.intermediate1],
+                    issuers: [Self.ca1, Self.ca1WithoutSubjectKeyIdentifier]
+                ),
+                .foundValidCertificateChain([Self.localhostLeaf, Self.intermediate1, Self.ca1]),
+            ]
+        )
+    }
 
     func testMissingIntermediateFailsToBuild() async throws {
         let roots = CertificateStore([Self.ca1])
@@ -785,7 +840,7 @@ final class VerifierTests: XCTestCase {
                 .searchingForIssuerOfPartialChain([Self.localhostLeaf]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.localhostLeaf],
-                    issuers: [Self.intermediate1WithoutSKIAKI, Self.intermediate1]
+                    issuers: [Self.intermediate1, Self.intermediate1WithoutSKIAKI]
                 ),
                 .searchingForIssuerOfPartialChain([Self.localhostLeaf, Self.intermediate1]),
                 .foundCandidateIssuersOfPartialChainInRootStore(
@@ -820,7 +875,7 @@ final class VerifierTests: XCTestCase {
                 .searchingForIssuerOfPartialChain([Self.localhostLeaf]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.localhostLeaf],
-                    issuers: [Self.intermediate1WithIncorrectSKIAKI, Self.intermediate1WithoutSKIAKI]
+                    issuers: [Self.intermediate1WithoutSKIAKI, Self.intermediate1WithIncorrectSKIAKI]
                 ),
                 .searchingForIssuerOfPartialChain([Self.localhostLeaf, Self.intermediate1WithoutSKIAKI]),
                 .foundCandidateIssuersOfPartialChainInRootStore(
@@ -938,7 +993,7 @@ final class VerifierTests: XCTestCase {
 
     func testInsanePKICanStillBuild() async throws {
         let roots = CertificateStore([Self.ca1])
-        let intermediates = CertificateStore([Self.t1, Self.t2, Self.t3, Self.x1, Self.x2])
+        let intermediates = CertificateStore([Self.t1, Self.t2, Self.t3, Self.x2, Self.x1])
         let log = DiagnosticsLog()
 
         var verifier = Verifier(rootCertificates: roots) { Self.defaultPolicy }
@@ -961,31 +1016,31 @@ final class VerifierTests: XCTestCase {
                 .searchingForIssuerOfPartialChain([Self.insaneLeaf]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.insaneLeaf],
-                    issuers: [Self.t1, Self.t2, Self.t3]
+                    issuers: [Self.t3, Self.t2, Self.t1]
                 ),
                 .issuerHasNotSignedCertificate(Self.t1, partialChain: [Self.insaneLeaf]),
                 .issuerHasNotSignedCertificate(Self.t2, partialChain: [Self.insaneLeaf]),
                 .searchingForIssuerOfPartialChain([Self.insaneLeaf, Self.t3]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.insaneLeaf, Self.t3],
-                    issuers: [Self.x1, Self.x2]
+                    issuers: [Self.x2, Self.x1]
                 ),
                 .searchingForIssuerOfPartialChain([Self.insaneLeaf, Self.t3, Self.x2]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.insaneLeaf, Self.t3, Self.x2],
-                    issuers: [Self.t1, Self.t2, Self.t3]
+                    issuers: [Self.t3, Self.t2, Self.t1]
                 ),
                 .issuerIsAlreadyInTheChain([Self.insaneLeaf, Self.t3, Self.x2], issuer: Self.t3),
                 .searchingForIssuerOfPartialChain([Self.insaneLeaf, Self.t3, Self.x2, Self.t2]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.insaneLeaf, Self.t3, Self.x2, Self.t2],
-                    issuers: [Self.x1, Self.x2]
+                    issuers: [Self.x2, Self.x1]
                 ),
                 .issuerIsAlreadyInTheChain([Self.insaneLeaf, Self.t3, Self.x2, Self.t2], issuer: Self.x2),
                 .searchingForIssuerOfPartialChain([Self.insaneLeaf, Self.t3, Self.x2, Self.t2, Self.x1]),
                 .foundCandidateIssuersOfPartialChainInIntermediateStore(
                     [Self.insaneLeaf, Self.t3, Self.x2, Self.t2, Self.x1],
-                    issuers: [Self.t1, Self.t2, Self.t3]
+                    issuers: [Self.t3, Self.t2, Self.t1]
                 ),
                 .issuerIsAlreadyInTheChain([Self.insaneLeaf, Self.t3, Self.x2, Self.t2, Self.x1], issuer: Self.t2),
                 .issuerIsAlreadyInTheChain([Self.insaneLeaf, Self.t3, Self.x2, Self.t2, Self.x1], issuer: Self.t3),
@@ -1247,9 +1302,9 @@ extension DiagnosticsLog: CustomDebugStringConvertible {
         \(self.diagnostics.enumerated().map {
             """
             \($0.0 + 1). ---------------------------------------------------------------------------------
-            \(String(reflecting: $0.1))
+            \($0.1.multilineDescription)
             """
-        }.joined(separator: "\n")),
+        }.joined(separator: "\n"))
         """
     }
 }


### PR DESCRIPTION
### Motivation
We prefer issuers that have a subject key identifier that matches the authority key identifier of the certificate for which were are searching for an issuer. However, currently we have flipped this sort order.

### Modifications
- Flip preference order
- update test
- add test which would previously fail

### Result
We actually prefer certificates in the order described above. 
Note that this is just a performance improvement.