### PR TITLE
Make PublicKey DERImplicitlyTaggable

### DIFF
--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -329,30 +329,27 @@ extension _RSA.Signing.PublicKey {
     }
 }
 
-extension Certificate.PublicKey {
+extension Certificate.PublicKey: PEMParseable, PEMSerializable {
     @inlinable
-    static var pemDiscriminator: String { "PUBLIC KEY" }
-
-    @inlinable
-    public init(pemEncoded: String) throws {
-        try self.init(pemDocument: PEMDocument(pemString: pemEncoded))
+    public static var defaultPEMDiscriminator: String {
+        return "PUBLIC KEY"
     }
+}
 
+extension Certificate.PublicKey: DERImplicitlyTaggable {
     @inlinable
-    public init(pemDocument: PEMDocument) throws {
-        guard pemDocument.discriminator == Self.pemDiscriminator else {
-            throw ASN1Error.invalidPEMDocument(
-                reason:
-                    "PEMDocument has incorrect discriminator \(pemDocument.discriminator). Expected \(Self.pemDiscriminator) instead"
-            )
-        }
-
-        try self.init(spki: try SubjectPublicKeyInfo(derEncoded: pemDocument.derBytes))
+    public static var defaultIdentifier: SwiftASN1.ASN1Identifier {
+        SubjectPublicKeyInfo.defaultIdentifier
     }
-
-    func serializeAsPEM() throws -> PEMDocument {
+    
+    @inlinable
+    public init(derEncoded: SwiftASN1.ASN1Node, withIdentifier identifier: SwiftASN1.ASN1Identifier) throws {
+        try self.init(spki: try SubjectPublicKeyInfo(derEncoded: derEncoded, withIdentifier: identifier))
+    }
+    
+    @inlinable
+    public func serialize(into coder: inout SwiftASN1.DER.Serializer, withIdentifier identifier: SwiftASN1.ASN1Identifier) throws {
         let spki = SubjectPublicKeyInfo(self)
-        let derBytes = try DER.Serializer.serialized(element: spki)
-        return PEMDocument(type: "PUBLIC KEY", derBytes: derBytes)
+        try spki.serialize(into: &coder, withIdentifier: identifier)
     }
 }

--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -341,14 +341,17 @@ extension Certificate.PublicKey: DERImplicitlyTaggable {
     public static var defaultIdentifier: SwiftASN1.ASN1Identifier {
         SubjectPublicKeyInfo.defaultIdentifier
     }
-    
+
     @inlinable
     public init(derEncoded: SwiftASN1.ASN1Node, withIdentifier identifier: SwiftASN1.ASN1Identifier) throws {
         try self.init(spki: try SubjectPublicKeyInfo(derEncoded: derEncoded, withIdentifier: identifier))
     }
-    
+
     @inlinable
-    public func serialize(into coder: inout SwiftASN1.DER.Serializer, withIdentifier identifier: SwiftASN1.ASN1Identifier) throws {
+    public func serialize(
+        into coder: inout SwiftASN1.DER.Serializer,
+        withIdentifier identifier: SwiftASN1.ASN1Identifier
+    ) throws {
         let spki = SubjectPublicKeyInfo(self)
         try spki.serialize(into: &coder, withIdentifier: identifier)
     }


### PR DESCRIPTION
Motivation:

PublicKey doesn't conform to DERImplicitlyTaggable which was an oversight during development.

Modifications:

Add conformance to DERImplicitlyTaggable, PEMSerializable, and PEMParsable.

Result:

PublicKey is DERImplicitlyTaggable.