### PR TITLE
Add `Certificate.PrivateKey` description

### DIFF
--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -161,8 +161,10 @@ extension Certificate.PrivateKey: CustomStringConvertible {
             return "P521.PrivateKey"
         case .rsa(let publicKey):
             return "RSA\(publicKey.keySizeInBits).PrivateKey"
+        #if canImport(Darwin)
         case .secureEnclaveP256:
             return "SecureEnclave.P256.PrivateKey"
+        #endif
         }
     }
 }

--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -152,7 +152,18 @@ extension Certificate.PrivateKey: Sendable {}
 
 extension Certificate.PrivateKey: CustomStringConvertible {
     public var description: String {
-        return "TODO"
+        switch self.backing {
+        case .p256:
+            return "P256.PrivateKey"
+        case .p384:
+            return "P384.PrivateKey"
+        case .p521:
+            return "P521.PrivateKey"
+        case .rsa(let publicKey):
+            return "RSA\(publicKey.keySizeInBits).PrivateKey"
+        case .secureEnclaveP256:
+            return "SecureEnclave.P256.PrivateKey"
+        }
     }
 }
 

--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -163,13 +163,13 @@ extension Certificate.PublicKey: CustomStringConvertible {
     public var description: String {
         switch self.backing {
         case .p256:
-            return "P256"
+            return "P256.PublicKey"
         case .p384:
-            return "P384"
+            return "P384.PublicKey"
         case .p521:
-            return "P521"
+            return "P521.PublicKey"
         case .rsa(let publicKey):
-            return "RSA\(publicKey.keySizeInBits)"
+            return "RSA\(publicKey.keySizeInBits).PublicKey"
         }
     }
 }

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -513,7 +513,7 @@ final class CertificateTests: XCTestCase {
             subject: "CN=Swift Certificate Test CA 1,O=Apple,C=US", \
             notValidBefore: 2022-08-08 14:26:14 +0000, \
             notValidAfter: 2033-08-05 14:26:14 +0000, \
-            publicKey: P384, \
+            publicKey: P384.PublicKey, \
             signature: ECDSA, \
             extensions: [\
             BasicConstraints(CA=TRUE), \
@@ -576,7 +576,7 @@ final class CertificateTests: XCTestCase {
             subject: "CN=Swift Certificate Test Intermediate CA 1,O=Apple,C=US", \
             notValidBefore: 2022-08-08 14:26:14 +0000, \
             notValidAfter: 2028-08-06 14:26:14 +0000, \
-            publicKey: P256, \
+            publicKey: P256.PublicKey, \
             signature: ECDSA, \
             extensions: [\
             BasicConstraints(CA=TRUE, maxPathLength=1), \
@@ -626,7 +626,7 @@ final class CertificateTests: XCTestCase {
             subject: "STREET=Infinite Loop,CN=localhost,O=Apple,C=US", \
             notValidBefore: 2022-08-08 14:26:14 +0000, \
             notValidAfter: 2024-08-07 14:26:14 +0000, \
-            publicKey: P256, \
+            publicKey: P256.PublicKey, \
             signature: ECDSA, \
             extensions: [\
             BasicConstraints(CA=FALSE), \


### PR DESCRIPTION
and update `Certificate.PublicKey` description to disambiguate from private keys.