### PR TITLE
Fix typos in Sources and Tests

### DIFF
--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -258,7 +258,7 @@ extension Certificate.PrivateKey {
                 let sec1 = try SEC1PrivateKey(derEncoded: pkcs8.privateKey.bytes)
                 if let innerAlgorithm = sec1.algorithm, innerAlgorithm != pkcs8.algorithm {
                     throw ASN1Error.invalidASN1Object(
-                        reason: "algorithm missmatch. PKCS#8 is \(pkcs8.algorithm) but inner SEC1 is \(innerAlgorithm)"
+                        reason: "algorithm mismatch. PKCS#8 is \(pkcs8.algorithm) but inner SEC1 is \(innerAlgorithm)"
                     )
                 }
                 self = try .init(ecdsaAlgorithm: pkcs8.algorithm, rawEncodedPrivateKey: sec1.privateKey.bytes)

--- a/Sources/X509/Extension Types/NameConstraints.swift
+++ b/Sources/X509/Extension Types/NameConstraints.swift
@@ -413,7 +413,7 @@ public struct NameConstraints {
     /// The DNS name trees that are permitted in certificates issued by this CA.
     ///
     /// These restrictions are expressed in forms like `host.example.com`. Any DNS name that can be
-    /// constructed by adding zero or more labels to the left-hand side of the name satifies the constraint.
+    /// constructed by adding zero or more labels to the left-hand side of the name satisfies the constraint.
     public internal(set) var permittedDNSDomains: DNSNames {
         get {
             DNSNames(subtrees: permittedSubtrees)

--- a/Sources/X509/ExtensionsBuilder.swift
+++ b/Sources/X509/ExtensionsBuilder.swift
@@ -117,7 +117,7 @@ public struct ExtensionsBuilder {
 ///
 /// Note that for most extension types, the returned ``Certificate/Extension`` should have its
 /// ``Certificate/Extension/critical`` value set to `false`. This allows the ``Critical`` helper
-/// type to fulfil its function as expected.
+/// type to fulfill its function as expected.
 public protocol CertificateExtensionConvertible {
     /// Convert the value into a ``Certificate/Extension``.
     func makeCertificateExtension() throws -> Certificate.Extension

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -597,7 +597,7 @@ extension OCSPSingleResponse {
         /// ensure the current time, expressed in GMT time as described in
         /// Section 2.2.4, falls between the thisUpdate and nextUpdate times.
 		/// If the nextUpdate field is absent, the client MUST reject the response.
-        /// https://www.rfc-editor.org/rfc/rfc5019#section-4
+		/// https://www.rfc-editor.org/rfc/rfc5019#section-4
         guard let nextUpdateGeneralizedTime = self.nextUpdate else {
             return .failsToMeetPolicy(reason: "OCSP response `nextUpdate` is nil")
         }

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -595,8 +595,8 @@ extension OCSPSingleResponse {
     ) -> PolicyEvaluationResult {
         /// Clients MUST check for the existence of the nextUpdate field and MUST
         /// ensure the current time, expressed in GMT time as described in
-        /// Section 2.2.4, falls between the thisUpdate and nextUpdate times.  Ifhttps://www.rfc-editor.org/rfc/rfc5019#section-4
-        /// the nextUpdate field is absent, the client MUST reject the response.
+        /// Section 2.2.4, falls between the thisUpdate and nextUpdate times.
+		/// If the nextUpdate field is absent, the client MUST reject the response.
         /// https://www.rfc-editor.org/rfc/rfc5019#section-4
         guard let nextUpdateGeneralizedTime = self.nextUpdate else {
             return .failsToMeetPolicy(reason: "OCSP response `nextUpdate` is nil")

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -596,8 +596,8 @@ extension OCSPSingleResponse {
         /// Clients MUST check for the existence of the nextUpdate field and MUST
         /// ensure the current time, expressed in GMT time as described in
         /// Section 2.2.4, falls between the thisUpdate and nextUpdate times.
-		/// If the nextUpdate field is absent, the client MUST reject the response.
-		/// https://www.rfc-editor.org/rfc/rfc5019#section-4
+        /// If the nextUpdate field is absent, the client MUST reject the response.
+        /// https://www.rfc-editor.org/rfc/rfc5019#section-4
         guard let nextUpdateGeneralizedTime = self.nextUpdate else {
             return .failsToMeetPolicy(reason: "OCSP response `nextUpdate` is nil")
         }

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -33,7 +33,7 @@ public struct Verifier<Policy: VerifierPolicy> {
 
         var policyFailures: [VerificationResult.PolicyFailure] = []
 
-        // First check: does this leaf certificate contain critical extensions that are not satisfied by the policy set?
+        // First check: does this leaf certificate contain critical extensions that are not satisfied by the PolicySet?
         // If so, reject the chain.
         if leafCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.verifyingCriticalExtensions) {
 

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -33,7 +33,7 @@ public struct Verifier<Policy: VerifierPolicy> {
 
         var policyFailures: [VerificationResult.PolicyFailure] = []
 
-        // First check: does this leaf certificate contain critical extensions that are not satisfied by the policyset?
+        // First check: does this leaf certificate contain critical extensions that are not satisfied by the policy set?
         // If so, reject the chain.
         if leafCertificate.hasUnhandledCriticalExtensions(handledExtensions: self.policy.verifyingCriticalExtensions) {
 

--- a/Sources/X509/X509BaseTypes/TimeCalculations.swift
+++ b/Sources/X509/X509BaseTypes/TimeCalculations.swift
@@ -167,7 +167,7 @@ extension Int64 {
         // Same for remdays, the loop only terminates if the number is smaller than at most 31.
         //
         // Note that, unlike struct tm, we return ordinal month numbers as well as days (i.e. 1 to 12).
-        // This fits us better when working with generalized time and friends.
+        // This fits us better when working with GeneralizedTime and friends.
         return (
             year: Int(years + 2000),
             month: Int(months &+ 3),

--- a/Sources/X509/X509BaseTypes/TimeCalculations.swift
+++ b/Sources/X509/X509BaseTypes/TimeCalculations.swift
@@ -154,7 +154,7 @@ extension Int64 {
         }
 
         // Now we normalise the months count back to starting in January.
-        // Safe to do unchecked subtraction here becuase for all numbers 10 or
+        // Safe to do unchecked subtraction here because for all numbers 10 or
         // larger we can subtract by 12.
         if months >= 10 {
             months &-= 12
@@ -167,7 +167,7 @@ extension Int64 {
         // Same for remdays, the loop only terminates if the number is smaller than at most 31.
         //
         // Note that, unlike struct tm, we return ordinal month numbers as well as days (i.e. 1 to 12).
-        // This fits us better when working with generalizedtime and friends.
+        // This fits us better when working with generalized time and friends.
         return (
             year: Int(years + 2000),
             month: Int(months &+ 3),

--- a/Tests/CertificateInternalsTests/TinyArrayTests.swift
+++ b/Tests/CertificateInternalsTests/TinyArrayTests.swift
@@ -28,12 +28,12 @@ final class TinyArrayTests: XCTestCase {
         XCTAssertEqual(Array(actual), Array(expected()), file: file, line: line)
         let expected = _TinyArray(expected())
         XCTAssertEqual(actual, expected, file: file, line: line)
-        var acutalHasher = Hasher()
-        acutalHasher.combine(actual)
+        var actualHasher = Hasher()
+        actualHasher.combine(actual)
         var expectedHasher = Hasher()
         expectedHasher.combine(expected)
         XCTAssertEqual(
-            acutalHasher.finalize(),
+            actualHasher.finalize(),
             expectedHasher.finalize(),
             "\(actual) does not have the same hash as \(expected)",
             file: file,

--- a/Tests/X509Tests/OCSPTests.swift
+++ b/Tests/X509Tests/OCSPTests.swift
@@ -161,7 +161,7 @@ final class OCSPTests: XCTestCase {
         }
     }
 
-    func testCRLReasionSerialization() throws {
+    func testCRLReasonSerialization() throws {
         let fixtures: [(CRLReason, Int)] = [
             (.unspecified, 0),
             (.keyCompromise, 1),


### PR DESCRIPTION
Fix some typos in `Sources` and `Tests`

Note: There is a complete mix of British vs American English spelling of (re/de)serialize vs serialise, but I refrain from changing those.