### PR TITLE
Add the `diagnosticCallback` to `CMS.isValidSignature`

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -93,6 +93,7 @@ public enum CMS {
         signatureBytes: SignatureBytes,
         additionalIntermediateCertificates: [Certificate] = [],
         trustRoots: CertificateStore,
+        diagnosticCallback: ((VerificationDiagnostic) -> Void)? = nil,
         @PolicyBuilder policy: () throws -> some VerifierPolicy
     ) async rethrows -> SignatureVerificationResult {
         let signedData: CMSSignedData
@@ -172,7 +173,11 @@ public enum CMS {
         untrustedIntermediates.insert(contentsOf: additionalIntermediateCertificates)
 
         var verifier = try Verifier(rootCertificates: trustRoots, policy: policy)
-        let result = await verifier.validate(leafCertificate: signingCert, intermediates: untrustedIntermediates)
+        let result = await verifier.validate(
+            leafCertificate: signingCert,
+            intermediates: untrustedIntermediates,
+            diagnosticCallback: diagnosticCallback
+        )
 
         switch result {
         case .validCertificate:

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -366,12 +366,20 @@ final class CMSTests: XCTestCase {
             certificate: Self.leaf1Cert,
             privateKey: Self.leaf1Key
         )
+        let log = DiagnosticsLog()
         let isValidSignature = await CMS.isValidSignature(
             dataBytes: data,
             signatureBytes: signature,
-            trustRoots: CertificateStore([Self.rootCert])
+            trustRoots: CertificateStore([Self.rootCert]),
+            diagnosticCallback: log.append(_:)
         ) { Self.defaultPolicies }
         XCTAssertValidSignature(isValidSignature)
+        
+        XCTAssertEqual(log, [
+            .searchingForIssuerOfPartialChain([Self.leaf1Cert]),
+            .foundCandidateIssuersOfPartialChainInRootStore([Self.leaf1Cert], issuers: [Self.rootCert]),
+            .foundValidCertificateChain([Self.leaf1Cert, Self.rootCert])
+        ])
     }
 
     func testParsingSimpleSignature() async throws {

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -374,12 +374,15 @@ final class CMSTests: XCTestCase {
             diagnosticCallback: log.append(_:)
         ) { Self.defaultPolicies }
         XCTAssertValidSignature(isValidSignature)
-        
-        XCTAssertEqual(log, [
-            .searchingForIssuerOfPartialChain([Self.leaf1Cert]),
-            .foundCandidateIssuersOfPartialChainInRootStore([Self.leaf1Cert], issuers: [Self.rootCert]),
-            .foundValidCertificateChain([Self.leaf1Cert, Self.rootCert])
-        ])
+
+        XCTAssertEqual(
+            log,
+            [
+                .searchingForIssuerOfPartialChain([Self.leaf1Cert]),
+                .foundCandidateIssuersOfPartialChainInRootStore([Self.leaf1Cert], issuers: [Self.rootCert]),
+                .foundValidCertificateChain([Self.leaf1Cert, Self.rootCert]),
+            ]
+        )
     }
 
     func testParsingSimpleSignature() async throws {


### PR DESCRIPTION
The CMS validation functions should have the diagnostic callback exposed.