### PR TITLE
Align `swift-format` configuration with other projects

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -47,7 +47,7 @@
     "UseLetInEveryBoundCaseVariable" : false,
     "UseShorthandTypeNames" : true,
     "UseSingleLinePropertyGetter" : false,
-    "UseSynthesizedInitializer" : true,
+    "UseSynthesizedInitializer" : false,
     "UseTripleSlashForDocumentationComments" : true,
     "UseWhereClausesInForLoops" : false,
     "ValidateDocumentationComments" : false

--- a/.swift-format
+++ b/.swift-format
@@ -29,7 +29,7 @@
     "NeverForceUnwrap" : false,
     "NeverUseForceTry" : false,
     "NeverUseImplicitlyUnwrappedOptionals" : false,
-    "NoAccessLevelOnExtensionDeclaration" : false,
+    "NoAccessLevelOnExtensionDeclaration" : true,
     "NoAssignmentInExpressions" : true,
     "NoBlockComments" : true,
     "NoCasesWithOnlyFallthrough" : true,
@@ -47,12 +47,12 @@
     "UseLetInEveryBoundCaseVariable" : false,
     "UseShorthandTypeNames" : true,
     "UseSingleLinePropertyGetter" : false,
-    "UseSynthesizedInitializer" : false,
+    "UseSynthesizedInitializer" : true,
     "UseTripleSlashForDocumentationComments" : true,
     "UseWhereClausesInForLoops" : false,
     "ValidateDocumentationComments" : false
   },
   "spacesAroundRangeFormationOperators" : false,
-  "tabWidth" : 8,
+  "tabWidth" : 4,
   "version" : 1
 }


### PR DESCRIPTION
No code change. We already followed these rules.