### PR TITLE
build: support building in Debug mode on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,10 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+if(POLICY CMP0091)
+  cmake_policy(SET CMP0091 NEW)
+endif()
+
 cmake_minimum_required(VERSION 3.19)
 
 project(SwiftCertificates
@@ -21,22 +25,20 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 include(SwiftSupport)
 
+option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
+set(CMAKE_Swift_COMPILE_OPTIONS_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
+set(CMAKE_MSVC_RUNTIME_LIBRARY MultiThreadedDLL)
+set(CMAKE_POSITION_INDEPENDENT_CODE ${BUILD_SHARED_LIBS})
 
-if(BUILD_SHARED_LIBS)
-  set(CMAKE_POSITION_INDEPENDENT_CODE YES)
-endif()
-
-if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
-  find_package(dispatch CONFIG)
-  find_package(Foundation CONFIG)
-endif()
+find_package(dispatch CONFIG)
+find_package(Foundation CONFIG)
 
 find_package(SwiftASN1 CONFIG REQUIRED)
 find_package(SwiftCrypto CONFIG REQUIRED)


### PR DESCRIPTION
With this tweak, we should be able to build the package in debug mode even on Windows. We always use the release mode DLL form of the C/C++ runtime on Windows and can build the Swift code in Debug or Release mode optimizations.