### PR TITLE
Support converting RDNAttribute values into Strings

### DIFF
--- a/Sources/X509/RDNAttribute.swift
+++ b/Sources/X509/RDNAttribute.swift
@@ -584,6 +584,22 @@ extension ASN1ObjectIdentifier {
     }
 }
 
+extension String {
+    /// Extract the textual representation of a given ``RelativeDistinguishedName/Attribute/Value-swift.struct``.
+    ///
+    /// Returns `nil` if the value is not a printable or UTF8 string.
+    public init?(_ value: RelativeDistinguishedName.Attribute.Value) {
+        switch value.storage {
+        case .printable(let printable):
+            self = printable
+        case .utf8(let utf8):
+            self = utf8
+        default:
+            return nil
+        }
+    }
+}
+
 extension RandomAccessCollection {
     @inlinable
     func suffix(while predicate: (Element) -> Bool) -> SubSequence {

--- a/Tests/X509Tests/DistinguishedNameTests.swift
+++ b/Tests/X509Tests/DistinguishedNameTests.swift
@@ -415,4 +415,16 @@ final class DistinguishedNameTests: XCTestCase {
             RelativeDistinguishedName.Attribute.Value(utf8String: String(repeating: "A", count: Int(UInt16.max) + 1))
         )
     }
+
+    func testRDNAttributeValuesCanBeConvertedToStrings() throws {
+        let examplesAndResults: [(RelativeDistinguishedName.Attribute, String?)] = try [
+            (.init(type: .RDNAttributeType.commonName, printableString: "foo"), "foo"),
+            (.init(type: .RDNAttributeType.commonName, utf8String: "bar"), "bar"),
+            (.init(type: .RDNAttributeType.commonName, value: ASN1Any(erasing: ASN1IA5String("foo"))), nil),
+        ]
+
+        for (example, result) in examplesAndResults {
+            XCTAssertEqual(String(example.value), result)
+        }
+    }
 }


### PR DESCRIPTION
Motivation

RDNAttribute Values are mostly strings, and it's useful to be able to convert them. This patch adds that support.

Modifications

Add support for converting RDN attribute values into Strings.

Result

Easier to work with distinguished names.