### PR TITLE
Simplify the internal representation of RDNAttribute.Value

### DIFF
--- a/Sources/X509/RDNAttribute.swift
+++ b/Sources/X509/RDNAttribute.swift
@@ -381,123 +381,11 @@ extension RelativeDistinguishedName.Attribute: DERImplicitlyTaggable {
             }
 
             let value: Value
-            switch type {
-            /// ```
-            /// id-at-commonName        AttributeType ::= { id-at 3 }
-            ///
-            /// -- Naming attributes of type X520CommonName:
-            /// --   X520CommonName ::= DirectoryName (SIZE (1..ub-common-name))
-            /// --
-            /// -- Expanded to avoid parameterized type:
-            /// X520CommonName ::= CHOICE {
-            ///       teletexString     TeletexString   (SIZE (1..ub-common-name)),
-            ///       printableString   PrintableString (SIZE (1..ub-common-name)),
-            ///       universalString   UniversalString (SIZE (1..ub-common-name)),
-            ///       utf8String        UTF8String      (SIZE (1..ub-common-name)),
-            ///       bmpString         BMPString       (SIZE (1..ub-common-name)) }
-            ///
-            ///
-            /// -- Naming attributes of type X520LocalityName
-            ///
-            /// id-at-localityName      AttributeType ::= { id-at 7 }
-            ///
-            /// -- Naming attributes of type X520LocalityName:
-            /// --   X520LocalityName ::= DirectoryName (SIZE (1..ub-locality-name))
-            /// --
-            /// -- Expanded to avoid parameterized type:
-            /// X520LocalityName ::= CHOICE {
-            ///       teletexString     TeletexString   (SIZE (1..ub-locality-name)),
-            ///       printableString   PrintableString (SIZE (1..ub-locality-name)),
-            ///       universalString   UniversalString (SIZE (1..ub-locality-name)),
-            ///       utf8String        UTF8String      (SIZE (1..ub-locality-name)),
-            ///       bmpString         BMPString       (SIZE (1..ub-locality-
-            ///
-            /// id-at-stateOrProvinceName AttributeType ::= { id-at 8 }
-            ///
-            ///
-            /// -- Naming attributes of type X520StateOrProvinceName:
-            /// --   X520StateOrProvinceName ::= DirectoryName (SIZE (1..ub-state-name))
-            /// --
-            /// -- Expanded to avoid parameterized type:
-            /// X520StateOrProvinceName ::= CHOICE {
-            ///       teletexString     TeletexString   (SIZE (1..ub-state-name)),
-            ///       printableString   PrintableString (SIZE (1..ub-state-name)),
-            ///       universalString   UniversalString (SIZE (1..ub-state-name)),
-            ///       utf8String        UTF8String      (SIZE (1..ub-state-name)),
-            ///       bmpString         BMPString       (SIZE (1..ub-state-name)) }
-            ///
-            ///
-            /// -- Naming attributes of type X520OrganizationName
-            ///
-            /// id-at-organizationName  AttributeType ::= { id-at 10 }
-            ///
-            /// -- Naming attributes of type X520OrganizationName:
-            /// --   X520OrganizationName ::=
-            /// --          DirectoryName (SIZE (1..ub-organization-name))
-            /// --
-            /// -- Expanded to avoid parameterized type:
-            /// X520OrganizationName ::= CHOICE {
-            ///       teletexString     TeletexString
-            ///                           (SIZE (1..ub-organization-name)),
-            ///       printableString   PrintableString
-            ///                           (SIZE (1..ub-organization-name)),
-            ///       universalString   UniversalString
-            ///                           (SIZE (1..ub-organization-name)),
-            ///       utf8String        UTF8String
-            ///                           (SIZE (1..ub-organization-name)),
-            ///       bmpString         BMPString
-            ///                           (SIZE (1..ub-organization-name))  }
-            ///
-            ///
-            /// id-at-organizationalUnitName AttributeType ::= { id-at 11 }
-            ///
-            /// -- Naming attributes of type X520OrganizationalUnitName:
-            /// --   X520OrganizationalUnitName ::=
-            /// --          DirectoryName (SIZE (1..ub-organizational-unit-name))
-            /// --
-            /// -- Expanded to avoid parameterized type:
-            /// X520OrganizationalUnitName ::= CHOICE {
-            ///       teletexString     TeletexString
-            ///                           (SIZE (1..ub-organizational-unit-name)),
-            ///       printableString   PrintableString
-            ///                           (SIZE (1..ub-organizational-unit-name)),
-            ///       universalString   UniversalString
-            ///                           (SIZE (1..ub-organizational-unit-name)),
-            ///       utf8String        UTF8String
-            ///                           (SIZE (1..ub-organizational-unit-name)),
-            ///       bmpString         BMPString
-            ///                           (SIZE (1..ub-organizational-unit-name)) }
-            /// ```
-            case .RDNAttributeType.commonName,
-                .RDNAttributeType.localityName,
-                .RDNAttributeType.stateOrProvinceName,
-                .RDNAttributeType.organizationName,
-                .RDNAttributeType.organizationalUnitName:
-
-                switch valueNode.identifier {
-                case ASN1UTF8String.defaultIdentifier:
-                    value = try .init(utf8String: String(ASN1UTF8String(derEncoded: valueNode)))
-                case ASN1PrintableString.defaultIdentifier:
-                    value = try .init(printableString: String(ASN1PrintableString(derEncoded: valueNode)))
-                default:
-                    value = .init(storage: .any(ASN1Any(derEncoded: valueNode)))
-                }
-
-            /// ```
-            /// -- Naming attributes of type X520countryName (digraph from IS 3166)
-            ///
-            /// id-at-countryName       AttributeType ::= { id-at 6 }
-            ///
-            /// X520countryName ::=     PrintableString (SIZE (2))
-            /// ```
-            case .RDNAttributeType.countryName:
-                switch valueNode.identifier {
-                case ASN1PrintableString.defaultIdentifier:
-                    value = try .init(printableString: String(ASN1PrintableString(derEncoded: valueNode)))
-                default:
-                    value = .init(storage: .any(ASN1Any(derEncoded: valueNode)))
-                }
-
+            switch valueNode.identifier {
+            case ASN1UTF8String.defaultIdentifier:
+                value = try .init(utf8String: String(ASN1UTF8String(derEncoded: valueNode)))
+            case ASN1PrintableString.defaultIdentifier:
+                value = try .init(printableString: String(ASN1PrintableString(derEncoded: valueNode)))
             default:
                 value = .init(storage: .any(ASN1Any(derEncoded: valueNode)))
             }
@@ -594,8 +482,14 @@ extension String {
             self = printable
         case .utf8(let utf8):
             self = utf8
-        default:
-            return nil
+        case .any(let value):
+            if let printable = try? ASN1PrintableString(asn1Any: value) {
+                self = String(printable)
+            } else if let utf8 = try? ASN1UTF8String(asn1Any: value) {
+                self = String(utf8)
+            } else {
+                return nil
+            }
         }
     }
 }

--- a/Tests/X509Tests/DistinguishedNameTests.swift
+++ b/Tests/X509Tests/DistinguishedNameTests.swift
@@ -427,4 +427,22 @@ final class DistinguishedNameTests: XCTestCase {
             XCTAssertEqual(String(example.value), result)
         }
     }
+
+    func testRDNAttributeValuesCanBeConvertedToStringsInSomeOfTheAnyCasesToo() throws {
+        let weirdOID: ASN1ObjectIdentifier = [1, 2, 3, 4, 5]
+
+        let examplesAndResults: [(RelativeDistinguishedName.Attribute, String?)] = try [
+            (.init(type: weirdOID, printableString: "foo"), "foo"),
+            (.init(type: weirdOID, utf8String: "bar"), "bar"),
+            (.init(type: weirdOID, value: ASN1Any(erasing: ASN1UTF8String("foo"))), "foo"),
+            (.init(type: weirdOID, value: ASN1Any(erasing: ASN1PrintableString("baz"))), "baz"),
+            (.init(type: weirdOID, value: ASN1Any(erasing: ASN1IA5String("foo"))), nil),
+            (.init(type: weirdOID, value: ASN1Any(erasing: 5)), nil),
+            (.init(type: weirdOID, value: ASN1Any(erasing: ASN1OctetString(contentBytes: [1, 2, 3, 4]))), nil),
+        ]
+
+        for (example, result) in examplesAndResults {
+            XCTAssertEqual(String(example.value), result)
+        }
+    }
 }


### PR DESCRIPTION
Motivation

The 1.1.0 release included a patch (#154) that supported converting RDNAttribute values into strings. This patch missed that the `.any` case may also have strings in it.

While investigating this limitation, I realised that the constructor function was excessively complex. While it attempted to coerce based on extra information in the ASN.1 specification, it always fell back into the `.any` case. This meant that as a practical matter we always took the same few paths, and so could safely simplify the code.

Modifications

Simplify DER decoding of RDNAttribute.Values.
Introspect the .any cases for UTF8 strings and Printable strings when converting to String.

Result

Faster construction, more flexible representation.