### PR TITLE
Move `ExpressibleByArrayLiteral` conformance of `_TinyArray` to the declaring module

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftASN1
-#if canImport(Darwin)
+#if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
 #else
 @preconcurrency import Foundation

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -14,7 +14,7 @@
 
 import SwiftASN1
 import Crypto
-#if canImport(Darwin)
+#if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
 #else
 @preconcurrency import Foundation

--- a/Sources/_CertificateInternals/_TinyArray.swift
+++ b/Sources/_CertificateInternals/_TinyArray.swift
@@ -32,6 +32,20 @@ extension _TinyArray: Equatable where Element: Equatable {}
 extension _TinyArray: Hashable where Element: Hashable {}
 extension _TinyArray: Sendable where Element: Sendable {}
 
+extension _TinyArray: ExpressibleByArrayLiteral {
+    @inlinable
+    public init(arrayLiteral elements: Element...) {
+        switch elements.count {
+        case 0:
+            self = .init()
+        case 1:
+            self = .init(CollectionOfOne(elements[0]))
+        default:
+            self = .init(elements)
+        }
+    }
+}
+
 extension _TinyArray: RandomAccessCollection {
     public typealias Element = Element
 

--- a/Tests/CertificateInternalsTests/TinyArrayTests.swift
+++ b/Tests/CertificateInternalsTests/TinyArrayTests.swift
@@ -66,6 +66,15 @@ final class TinyArrayTests: XCTestCase {
         XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4])), [1, 2, 3, 4])
         XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5])
     }
+    
+    func testExpressibleByArrayLiteral() {
+        XCTAssertEqual(Array([] as _TinyArray<Int>), [])
+        XCTAssertEqual(Array([1] as _TinyArray<Int>), [1])
+        XCTAssertEqual(Array([1, 2] as _TinyArray<Int>), [1, 2])
+        XCTAssertEqual(Array([1, 2, 3] as _TinyArray<Int>), [1, 2, 3])
+        XCTAssertEqual(Array([1, 2, 3, 4] as _TinyArray<Int>), [1, 2, 3, 4])
+        XCTAssertEqual(Array([1, 2, 3, 4, 5] as _TinyArray<Int>), [1, 2, 3, 4, 5])
+    }
 
     func testAppend() {
         assertEqual([1]) { array in
@@ -337,13 +346,5 @@ final class TinyArrayTests: XCTestCase {
                 try _TinyArray<Int>([.success(1), .success(2), .success(3), .success(4), Result.failure(MyError())])
             )
         )
-    }
-}
-
-extension _TinyArray: ExpressibleByArrayLiteral {
-    public typealias ArrayLiteralElement = Element
-
-    public init(arrayLiteral elements: Element...) {
-        self.init(elements)
     }
 }

--- a/Tests/CertificateInternalsTests/TinyArrayTests.swift
+++ b/Tests/CertificateInternalsTests/TinyArrayTests.swift
@@ -66,7 +66,7 @@ final class TinyArrayTests: XCTestCase {
         XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4])), [1, 2, 3, 4])
         XCTAssertEqual(Array(_TinyArray<Int>([1, 2, 3, 4, 5])), [1, 2, 3, 4, 5])
     }
-    
+
     func testExpressibleByArrayLiteral() {
         XCTAssertEqual(Array([] as _TinyArray<Int>), [])
         XCTAssertEqual(Array([1] as _TinyArray<Int>), [1])

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -16,7 +16,7 @@ import XCTest
 import Crypto
 import SwiftASN1
 @testable import X509
-#if canImport(Darwin)
+#if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
 #else
 @preconcurrency import Foundation


### PR DESCRIPTION
### Motivation

Nightly compilers start complaining about retroactive conformances.

### Modifications

- move conformance to declaring module
- optimise code to not allocate
- add tests

### Result

no warning. optimal generated code for:

```swift
func foo1(int: Int) -> _TinyArray<Int> {
    [int]
}
```

which now compiles down to:
```
output.foo1(int: Swift.Int) -> output._TinyArray<Swift.Int>:
        mov     rax, rdi
        xor     edx, edx
        ret
```
(only with nightly compiler)

https://godbolt.org/z/a91fPe6or