### PR TITLE
Add missing availability guards in tests

### DIFF
--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -474,6 +474,7 @@ final class CertificateTests: XCTestCase {
 
     private static let referenceTime = Date(timeIntervalSince1970: 1_691_504_774)
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testCertificateDescription() throws {
         let caPrivateKey = P384.Signing.PrivateKey()
         let certificateName1 = try! DistinguishedName {

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -123,6 +123,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
     }
     private static let ca1PrivateKey = P384.Signing.PrivateKey()
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     private static func ca(ocspServer: String? = nil) -> Certificate {
         try! Certificate(
             version: .v3,
@@ -153,6 +154,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
             issuerPrivateKey: .init(ca1PrivateKey)
         )
     }
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     private static let ca1: Certificate = ca()
 
     fileprivate static let intermediatePrivateKey = P384.Signing.PrivateKey()
@@ -244,6 +246,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         CommonName("Swift Certificate Test Responder Intermediate 1")
     }
     private static let responderIntermediate1PrivateKey = P384.Signing.PrivateKey()
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     private static let invalidResponderIntermediate1 = try! Certificate(
         version: .v3,
         serialNumber: .init(),
@@ -491,6 +494,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         )
     }
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testInvalidResponderCertChain() async {
         let now = self.validationTime
         await self.assertChain(
@@ -609,6 +613,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         )
     }
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testShouldNotQueryResponderIfNoOCSPServerIsDefined() async {
         await self.assertChain(
             soft: .meetsPolicy,
@@ -626,6 +631,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         )
     }
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testLastCertificateIsNotAllowedToHaveOCSP() async {
         await self.assertChain(
             soft: .failsToMeetPolicy,

--- a/Tests/X509Tests/PEMTests.swift
+++ b/Tests/X509Tests/PEMTests.swift
@@ -37,27 +37,34 @@ extension Key {
 
 // MARK: Private Keys
 
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P256.Signing.PrivateKey: Key {
     var wrapped: Certificate.PrivateKey { .init(self) }
 }
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P384.Signing.PrivateKey: Key {
     var wrapped: Certificate.PrivateKey { .init(self) }
 }
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P521.Signing.PrivateKey: Key {
     var wrapped: Certificate.PrivateKey { .init(self) }
 }
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension _CryptoExtras._RSA.Signing.PrivateKey: Key {
     var wrapped: Certificate.PrivateKey { .init(self) }
 }
 
 // MARK: Public Keys
 
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P256.Signing.PublicKey: Key {
     var wrapped: Certificate.PublicKey { .init(self) }
 }
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P384.Signing.PublicKey: Key {
     var wrapped: Certificate.PublicKey { .init(self) }
 }
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Crypto.P521.Signing.PublicKey: Key {
     var wrapped: Certificate.PublicKey { .init(self) }
 }
@@ -71,6 +78,7 @@ private protocol WrappedKey: Equatable {
 }
 
 extension Certificate.PublicKey: WrappedKey {}
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 extension Certificate.PrivateKey: WrappedKey {}
 
 final class PEMTests: XCTestCase {
@@ -110,6 +118,7 @@ final class PEMTests: XCTestCase {
         try assertPEMRoundtrip(key: _RSA.Signing.PrivateKey(keySize: .bits2048))
     }
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testRSAPrivateKey() throws {
         // generated with "openssl genpkey -algorithm rsa"
         let rsaKey = try String(

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -18,6 +18,7 @@ import SwiftASN1
 @testable import X509
 import Crypto
 
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
 final class VerifierTests: XCTestCase {
     private static let referenceTime = Date()
 


### PR DESCRIPTION
## Motivation

Some of the test code was missing availability guards for Apple platforms, resulting in build failures for these platforms, e.g.

```
error: 'init(pemDocument:)' is only available in iOS 14 or newer
             let privateKeyAfterRoundtrip = try Certificate.PrivateKey(pemDocument: privateKey.serializeAsPEM())
```

## Modifications

Add missing availability guards. I've tried to keep them as scoped as possible. Some of the tests rely on initializers in `CryptoKit` that are only available since iOS 14. One suite of tests used this so extensively that I made the whole suite only available on newer platforms.

## Result

Tests can now build and run on iOS and other Apple platforms.