### PR TITLE
Remove now-breaking test vector test

### DIFF
--- a/Tests/X509Tests/CSRTests.swift
+++ b/Tests/X509Tests/CSRTests.swift
@@ -298,18 +298,6 @@ final class CSRTests: XCTestCase {
         XCTAssertThrowsError(try csr.attributes.extensionRequest)
     }
 
-    func testInvalidSignature() throws {
-        let url = Bundle.module.url(
-            forResource: "invalid_signature",
-            withExtension: "pem",
-            subdirectory: "CSR Vectors/cryptography"
-        )!
-        let bytes = try String(decoding: Data(contentsOf: url), as: UTF8.self)
-        let csr = try CertificateSigningRequest(pemEncoded: bytes)
-
-        XCTAssertFalse(csr.publicKey.isValidSignature(csr.signature, for: csr))
-    }
-
     func testRSASHA256Signature() throws {
         let url = Bundle.module.url(
             forResource: "rsa_sha256",


### PR DESCRIPTION
This test no longer passes with Swift Crypto main, as it relies on RSA 1024 which we now forbid