### PR TITLE
Allow OneOfPolicies and AllOfPolicies to take throwing policy builders, to match Verifier

### DIFF
--- a/Sources/X509/Verifier/AllOfPolicies.swift
+++ b/Sources/X509/Verifier/AllOfPolicies.swift
@@ -37,7 +37,12 @@ public struct AllOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     var policy: Policy
 
     @inlinable
-    public init(@PolicyBuilder policy: () throws -> Policy) rethrows {
+    public init(@PolicyBuilder policy: () throws -> Policy) throws {
+        self.policy = try policy()
+    }
+
+    @inlinable
+    public init(@PolicyBuilder policy: () -> Policy) {
         self.policy = try policy()
     }
 

--- a/Sources/X509/Verifier/AllOfPolicies.swift
+++ b/Sources/X509/Verifier/AllOfPolicies.swift
@@ -43,7 +43,7 @@ public struct AllOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
 
     @inlinable
     public init(@PolicyBuilder policy: () -> Policy) {
-        self.policy = try policy()
+        self.policy = policy()
     }
 
     @inlinable

--- a/Sources/X509/Verifier/AllOfPolicies.swift
+++ b/Sources/X509/Verifier/AllOfPolicies.swift
@@ -37,8 +37,8 @@ public struct AllOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     var policy: Policy
 
     @inlinable
-    public init(@PolicyBuilder policy: () -> Policy) {
-        self.policy = policy()
+    public init(@PolicyBuilder policy: () throws -> Policy) rethrows {
+        self.policy = try policy()
     }
 
     @inlinable

--- a/Sources/X509/Verifier/OneOfPolicies.swift
+++ b/Sources/X509/Verifier/OneOfPolicies.swift
@@ -177,8 +177,8 @@ public struct OneOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     var policy: Policy
 
     @inlinable
-    public init(@OneOfPolicyBuilder policy: () -> Policy) {
-        self.policy = policy()
+    public init(@OneOfPolicyBuilder policy: () throws -> Policy) rethrows {
+        self.policy = try policy()
     }
 
     @inlinable

--- a/Sources/X509/Verifier/OneOfPolicies.swift
+++ b/Sources/X509/Verifier/OneOfPolicies.swift
@@ -177,7 +177,12 @@ public struct OneOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     var policy: Policy
 
     @inlinable
-    public init(@OneOfPolicyBuilder policy: () throws -> Policy) rethrows {
+    public init(@OneOfPolicyBuilder policy: () throws -> Policy) throws {
+        self.policy = try policy()
+    }
+
+    @inlinable
+    public init(@OneOfPolicyBuilder policy: () -> Policy) {
         self.policy = try policy()
     }
 

--- a/Sources/X509/Verifier/OneOfPolicies.swift
+++ b/Sources/X509/Verifier/OneOfPolicies.swift
@@ -183,7 +183,7 @@ public struct OneOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
 
     @inlinable
     public init(@OneOfPolicyBuilder policy: () -> Policy) {
-        self.policy = try policy()
+        self.policy = policy()
     }
 
     @inlinable

--- a/Tests/X509Tests/PolicyBuilderTests.swift
+++ b/Tests/X509Tests/PolicyBuilderTests.swift
@@ -576,4 +576,48 @@ final class PolicyBuilderTests: XCTestCase {
             }
         }
     }
+
+    func testAllOfPoliciesThrowing() {
+        // Creating a AllOfPolicies which throws an error inside will itself throw
+        struct TestError: Error {}
+        func throwingPolicyBuilder() throws -> Policy {
+            throw TestError()
+        }
+
+        XCTAssertThrowsError(try AllOfPolicies {
+            try throwingPolicyBuilder()
+        }) { error in
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testAllOfPoliciesNonThrowing() {
+        // creating a AllOfPolicies with a non-throwing closure can't throw
+        // This is tested at compile time (lack of `try` keyword)
+        _ = AllOfPolicies {
+            Policy(result: .meetsPolicy)
+        }
+    }
+
+    func testOneOfPoliciesThrowing() {
+        // Creating a OneOfPolicies which throws an error inside will itself throw
+        struct TestError: Error {}
+        func throwingPolicyBuilder() throws -> Policy {
+            throw TestError()
+        }
+
+        XCTAssertThrowsError(try OneOfPolicies {
+            try throwingPolicyBuilder()
+        }) { error in
+            XCTAssertTrue(error is TestError)
+        }
+    }
+
+    func testOneOfPoliciesNonThrowing() {
+        // creating a OneOfPolicies with a non-throwing closure can't throw
+        // This is tested at compile time (lack of `try` keyword)
+        _ = OneOfPolicies {
+            Policy(result: .meetsPolicy)
+        }
+    }
 }

--- a/Tests/X509Tests/PolicyBuilderTests.swift
+++ b/Tests/X509Tests/PolicyBuilderTests.swift
@@ -584,9 +584,11 @@ final class PolicyBuilderTests: XCTestCase {
             throw TestError()
         }
 
-        XCTAssertThrowsError(try AllOfPolicies {
-            try throwingPolicyBuilder()
-        }) { error in
+        XCTAssertThrowsError(
+            try AllOfPolicies {
+                try throwingPolicyBuilder()
+            }
+        ) { error in
             XCTAssertTrue(error is TestError)
         }
     }
@@ -606,9 +608,11 @@ final class PolicyBuilderTests: XCTestCase {
             throw TestError()
         }
 
-        XCTAssertThrowsError(try OneOfPolicies {
-            try throwingPolicyBuilder()
-        }) { error in
+        XCTAssertThrowsError(
+            try OneOfPolicies {
+                try throwingPolicyBuilder()
+            }
+        ) { error in
             XCTAssertTrue(error is TestError)
         }
     }


### PR DESCRIPTION
This matches what verifier does (https://github.com/apple/swift-certificates/blob/83640c8097acaec17c9835a083e89678cb0f2b66/Sources/X509/Verifier/Verifier.swift#L22) and allows users to more easily use policies which throw in their initialiser