### PR TITLE
Adds support for including signing time in signedAttrs for CMS signing.

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -27,7 +27,7 @@ public enum CMS {
         signingTime: Date? = nil
     ) throws -> [UInt8] {
         if let signingTime = signingTime {
-            return try signWithSigningTime(
+            return try self.signWithSigningTime(
                 bytes,
                 signatureAlgorithm: signatureAlgorithm,
                 certificate: certificate,
@@ -45,7 +45,7 @@ public enum CMS {
             certificate: certificate
         )
 
-        return try serializeSignedData(signedData)
+        return try self.serializeSignedData(signedData)
     }
 
     @inlinable
@@ -93,7 +93,7 @@ public enum CMS {
             certificate: certificate,
             signedAttrs: signedAttrs
         )
-        return try serializeSignedData(signedData)
+        return try self.serializeSignedData(signedData)
     }
 
     @_spi(CMS)

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -15,6 +15,11 @@ import Foundation
 import SwiftASN1
 import Crypto
 
+public enum CMSSigningError: Error {
+    case noTimeZone
+    case invalidSigningDateComponent(dateComponents: DateComponents, requiredComponents: Set<Calendar.Component>)
+}
+
 public enum CMS {
     @_spi(CMS)
     @inlinable
@@ -23,15 +28,82 @@ public enum CMS {
         signatureAlgorithm: Certificate.SignatureAlgorithm,
         additionalIntermediateCertificates: [Certificate] = [],
         certificate: Certificate,
-        privateKey: Certificate.PrivateKey
+        privateKey: Certificate.PrivateKey,
+        includeSigningTime: Bool = false
     ) throws -> [UInt8] {
-        let signature = try privateKey.sign(bytes: bytes, signatureAlgorithm: signatureAlgorithm)
-        return try sign(
+        var signature: Certificate.Signature
+        var completeSignedAttrs: [CMSAttribute]? = nil
+        if includeSigningTime {
+            var signedAttrs: [CMSAttribute] = []
+            // As specified in RFC 5652 section 11 when including signedAttrs we need to include a minimum of:
+            // 1. content-type
+            // 2. message-digest
+
+            // add content-type signedAttr cms data
+            let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
+            let contentTypeAttribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
+            signedAttrs.append(contentTypeAttribute)
+
+            // add message-digest sha256 of provided content bytes
+            try SHA256.hash(data: bytes).withUnsafeBytes { bufferPointer in
+                let messageDigest = ASN1OctetString(contentBytes: ArraySlice(bufferPointer))
+                let messageDigestVal = try ASN1Any(erasing: messageDigest)
+                let messageDigestAttribute = CMSAttribute(attrType: .messageDigest, attrValues: [messageDigestVal])
+                signedAttrs.append(messageDigestAttribute)
+            }
+
+            // add signing time utc time in 'YYMMDDHHMMSSZ' format as specificed in `UTCTime`
+            let desiredComponents: Set = [
+                Calendar.Component.year,
+                Calendar.Component.month,
+                Calendar.Component.day,
+                Calendar.Component.hour,
+                Calendar.Component.minute,
+                Calendar.Component.second,
+            ]
+            guard let timeZone = TimeZone(identifier: "UTC") else {
+                throw CMSSigningError.noTimeZone
+            }
+            var calendar = Calendar(identifier: .gregorian)
+            calendar.timeZone = timeZone
+            let nowComponents = calendar.dateComponents(desiredComponents, from: Date())
+            guard let year = nowComponents.year,
+                let month = nowComponents.month,
+                let day = nowComponents.day,
+                let hour = nowComponents.hour,
+                let min = nowComponents.minute,
+                let sec = nowComponents.second
+            else {
+                throw CMSSigningError.invalidSigningDateComponent(
+                    dateComponents: nowComponents,
+                    requiredComponents: desiredComponents
+                )
+            }
+            let utcTime = try UTCTime((year: year, month: month, day: day, hours: hour, minutes: min, seconds: sec))
+            let signingTimeAttrVal = try ASN1Any(erasing: utcTime)
+            let signingTimeAttribute = CMSAttribute(attrType: .signingTime, attrValues: [signingTimeAttrVal])
+            signedAttrs.append(signingTimeAttribute)
+
+            // As specified in RFC 5652 section 5.4:
+            // When the [signedAttrs] field is present, however, the result is the message digest of the complete DER encoding of the SignedAttrs value contained in the signedAttrs field.
+            var coder = DER.Serializer()
+            try coder.serializeSetOf(signedAttrs)
+            let signedAttrBytes = coder.serializedBytes[...]
+            signature = try privateKey.sign(bytes: signedAttrBytes, signatureAlgorithm: signatureAlgorithm)
+            completeSignedAttrs = signedAttrs
+        } else {
+            signature = try privateKey.sign(bytes: bytes, signatureAlgorithm: signatureAlgorithm)
+        }
+
+        let signedData = try self.generateSignedData(
             signatureBytes: ASN1OctetString(signature),
             signatureAlgorithm: signatureAlgorithm,
             additionalIntermediateCertificates: additionalIntermediateCertificates,
-            certificate: certificate
+            certificate: certificate,
+            signedAttrs: completeSignedAttrs
         )
+
+        return try serializeSignedData(signedData)
     }
 
     @_spi(CMS)
@@ -49,8 +121,15 @@ public enum CMS {
             certificate: certificate
         )
 
+        return try serializeSignedData(signedData)
+    }
+
+    @inlinable
+    static func serializeSignedData(
+        _ contentInfo: CMSContentInfo
+    ) throws -> [UInt8] {
         var serializer = DER.Serializer()
-        try serializer.serialize(signedData)
+        try serializer.serialize(contentInfo)
         return serializer.serializedBytes
     }
 
@@ -59,7 +138,8 @@ public enum CMS {
         signatureBytes: ASN1OctetString,
         signatureAlgorithm: Certificate.SignatureAlgorithm,
         additionalIntermediateCertificates: [Certificate],
-        certificate: Certificate
+        certificate: Certificate,
+        signedAttrs: [CMSAttribute]? = nil
     ) throws -> CMSContentInfo {
         let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
         let contentInfo = CMSEncapsulatedContentInfo(eContentType: .cmsData)
@@ -67,6 +147,7 @@ public enum CMS {
         let signerInfo = CMSSignerInfo(
             signerIdentifier: .init(issuerAndSerialNumber: certificate),
             digestAlgorithm: digestAlgorithm,
+            signedAttrs: signedAttrs,
             signatureAlgorithm: AlgorithmIdentifier(signatureAlgorithm),
             signature: signatureBytes
         )
@@ -398,5 +479,29 @@ extension Certificate.Signature {
             signatureAlgorithm: signatureAlgorithm,
             signatureBytes: ASN1BitString(bytes: signatureBytes.bytes)
         )
+    }
+}
+
+extension CMSSigningError: LocalizedError {
+    public var errorDescription: String? {
+        switch self {
+        case .noTimeZone:
+            return NSLocalizedString("Unable to use UTC Time Zone", comment: "Unable to use UTC Time Zone")
+        case .invalidSigningDateComponent:
+            return NSLocalizedString("Missing date components", comment: "Missing date components")
+        }
+    }
+
+    public var failureReason: String? {
+        switch self {
+        case .noTimeZone:
+            return nil
+        case .invalidSigningDateComponent(let dateComponents, let requiredComponents):
+            return NSLocalizedString(
+                "Expected date components:\(requiredComponents). Received date components:\(dateComponents)",
+                comment:
+                    "Expected Date Components:[list of required calendar components]. Received date components:[provided date components]"
+            )
+        }
     }
 }

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -283,4 +283,7 @@ extension ASN1ObjectIdentifier {
 
     @usableFromInline
     static let signingTime: Self = [1, 2, 840, 113549, 1, 9, 5]
+
+    @usableFromInline
+    static let contentType: Self = [1, 2, 840, 113549, 1, 9, 3]
 }


### PR DESCRIPTION
Motivation:

Many CMS signing validations require the inclusion of signing time in signedAttrs (for example Apple Wallet's Pass CMS signing validation)

Modifications:

* Adds optional includeSigningTime flag to CMS.sign method (defaults to false)
* When includeSigningTime flag is true: includes signing-time (UTCTime ASN1Type), content-type, and message-digest signedAttrs and signs those instead of content bytes (as specified in RFC 5652 section 5.4)
* Adds contentType ASN1ObjectIdentifier
* Adds CMSSigningError (noTimeZone, invalidSigningDateComponent) for when includeSigningTime is true and unable to get UTC time zone or date components
* Adds tests for valid and invalid CMS signature when including signedAttrs

Result:

Providing the includeSigningTime = true flag to CMS.sign will cause signing-time, content-type, and message-digest signedAttrs to be included in the CMS signature and the signature bytes will represent signing those signedAttrs. Using CMS.sign without the flag (defaulting to false) should leave the previous CMS.sign behavior unchanged.

Resolves: https://github.com/apple/swift-certificates/issues/147

Submitted on behalf of Zetetic, LLC