### PR TITLE
Add bridge between `Certificate` and `Security.SecCertificate`

### DIFF
--- a/Sources/X509/Certificate.swift
+++ b/Sources/X509/Certificate.swift
@@ -295,3 +295,28 @@ extension Certificate: PEMRepresentable {
     @inlinable
     public static var defaultPEMDiscriminator: String { "CERTIFICATE" }
 }
+
+#if canImport(Security)
+import Security
+extension Certificate {
+    /// Creates an instance of `Certifcate` from `SecCertificate`
+    /// - Parameter certificate: The `SecCertificate` instance used to initialize this new `Certificate` instance
+    public init(_ certificate: SecCertificate) throws {
+        try self.init(derEncoded: Array(SecCertificateCopyData(certificate) as Data))
+    }
+}
+
+extension SecCertificate {
+    /// Creates an instance of `SecCertificate` from `Certificate`
+    /// - Parameter certificate: The `Certificate` instance used to initialize this new `SecCertificate` instance
+    /// - Returns: A new `SecCertificate` instance based on the provided `Certificate` instance
+    public static func createWithCertificate(_ certificate: Certificate) throws -> SecCertificate {
+        var coder = DER.Serializer()
+        try certificate.serialize(into: &coder)
+
+        let derData = Data(coder.serializedBytes)
+
+        return SecCertificateCreateWithData(nil, derData as CFData)!
+    }
+}
+#endif

--- a/Sources/X509/Certificate.swift
+++ b/Sources/X509/Certificate.swift
@@ -58,6 +58,11 @@ import SwiftASN1
 /// across the rest of the data. Allowing users to change this data makes it easy to accidentally modify
 /// a ``Certificate`` in one part of your code and not realise that the signature has inevitably
 /// been invalidated.
+///
+/// ### Creating Certificates from SecCertificate and vice versa
+///
+/// An instance of ``Certificate`` can be created from ``Security/SecCertificate`` (from the ``Security`` framework) with ``Certificate/init(_:)``.
+/// The opposite, that is, creating an instance of ``Security/SecCertificate`` from ``Certificate``, can be achieved with ``Security/SecCertificate/makeWithCertificate(_:)``.
 public struct Certificate {
     /// The X.509 version of this certificate.
     ///
@@ -299,7 +304,8 @@ extension Certificate: PEMRepresentable {
 #if canImport(Security)
 import Security
 extension Certificate {
-    /// Creates an instance of `Certifcate` from `SecCertificate`
+    /// Creates an instance of ``Certificate`` from ``Security/SecCertificate``.
+    /// To create an instance of ``Security/SecCertificate``, use ``Security/SecCertificate/makeWithCertificate(_:)`` instead.
     /// - Parameter certificate: The `SecCertificate` instance used to initialize this new `Certificate` instance
     public init(_ certificate: SecCertificate) throws {
         try self.init(derEncoded: Array(SecCertificateCopyData(certificate) as Data))
@@ -307,10 +313,11 @@ extension Certificate {
 }
 
 extension SecCertificate {
-    /// Creates an instance of `SecCertificate` from `Certificate`
+    /// Creates an instance of ``Security/SecCertificate`` from ``Certificate``.
+    /// To create an instance of ``Certificate``, use ``Certificate/init(_:)`` instead.
     /// - Parameter certificate: The `Certificate` instance used to initialize this new `SecCertificate` instance
     /// - Returns: A new `SecCertificate` instance based on the provided `Certificate` instance
-    public static func createWithCertificate(_ certificate: Certificate) throws -> SecCertificate {
+    public static func makeWithCertificate(_ certificate: Certificate) throws -> SecCertificate {
         var coder = DER.Serializer()
         try certificate.serialize(into: &coder)
 

--- a/Sources/X509/Docs.docc/Creating Certificates.md
+++ b/Sources/X509/Docs.docc/Creating Certificates.md
@@ -178,3 +178,8 @@ try serializer.serialize(certificate)
 let derEncodedCertificate = serializer.serializedBytes
 let derEncodedPrivateKey = swiftCryptoKey.derRepresentation
 ```
+
+### Creating Certificates from SecCertificate and vice versa
+
+An instance of ``Certificate`` can be created from ``Security/SecCertificate`` (from the ``Security`` framework) with ``Certificate/init(_:)``.
+The opposite, that is, creating an instance of ``Security/SecCertificate`` from ``Certificate``, can be achieved with ``Security/SecCertificate/makeWithCertificate(_:)``.

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -19,6 +19,10 @@ import SwiftASN1
 import Crypto
 import _CryptoExtras
 
+#if canImport(Security)
+import Security
+#endif
+
 final class CertificateDERTests: XCTestCase {
     static let base64EncodedSampleCert = """
         MIIDsjCCAzigAwIBAgIQDKuq0c7E6XzCZliB0CE49zAKBggqhkjOPQQDAzBhMQsw
@@ -163,6 +167,20 @@ final class CertificateDERTests: XCTestCase {
         UKqK1drk/NAJBzewdXUh
         """,
     ]
+
+    #if canImport(Security)
+    func testSecCertificateBridge() throws {
+        let certificateData = Data(base64Encoded: Self.base64EncodedSampleCert, options: .ignoreUnknownCharacters)!
+        let binary = Array(certificateData)
+
+        let cert = try Certificate(derEncoded: binary)
+
+        let certConvertedToSecCert = try SecCertificate.createWithCertificate(cert)
+        let secCertConvertedToCert = try Certificate(certConvertedToSecCert)
+
+        XCTAssertEqual(cert, secCertConvertedToCert)
+    }
+    #endif
 
     func testSimpleDecode() throws {
         let binary = Array(Data(base64Encoded: Self.base64EncodedSampleCert, options: .ignoreUnknownCharacters)!)

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -175,7 +175,7 @@ final class CertificateDERTests: XCTestCase {
 
         let cert = try Certificate(derEncoded: binary)
 
-        let certConvertedToSecCert = try SecCertificate.createWithCertificate(cert)
+        let certConvertedToSecCert = try SecCertificate.makeWithCertificate(cert)
         let secCertConvertedToCert = try Certificate(certConvertedToSecCert)
 
         XCTAssertEqual(cert, secCertConvertedToCert)


### PR DESCRIPTION
### Motivation:

Currently, there is no way to create an instance of `Certificate` from `Security.SecCertificate` and vice versa (GitHub Issue #168).

### Modifications:

- Added an initializer to `Certificate` which constructs an instance from `Security.SecCertificate`.
- Added a static function `createWithCertificate(_ certificate: Certificate)` in an extension to `Security.SecCertificate` which returns a `SecCertificate` instance.
  - Various errors when trying to add an initializer in an extension of `Security.SecCertificate` -- this is presumably because `SecCertificate` is defined in C.

### Result:

Users can create an instance of `Certificate` from `Security.SecCertificate` and vice versa.