### PR TITLE
Add support for Android

### DIFF
--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -23,6 +23,9 @@ import Musl
 import CoreFoundation
 #elseif canImport(Darwin)
 import Darwin
+#elseif canImport(Android)
+import Android
+import CoreFoundation
 #endif
 
 extension NameConstraintsPolicy {


### PR DESCRIPTION
Tested natively on Android AArch64 with a recent trunk Swift toolchain, no problems.