### PR TITLE
Use filePath for test assert location

### DIFF
--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -1008,7 +1008,7 @@ extension DERSerializable {
 
 private func XCTAssertValidSignature(
     _ result: CMS.SignatureVerificationResult,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     guard case .success = result else {
@@ -1019,7 +1019,7 @@ private func XCTAssertValidSignature(
 
 private func XCTAssertInvalidCMSBlock(
     _ result: CMS.SignatureVerificationResult,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     guard case .failure(.invalidCMSBlock) = result else {
@@ -1030,7 +1030,7 @@ private func XCTAssertInvalidCMSBlock(
 
 private func XCTAssertUnableToValidateSigner(
     _ result: CMS.SignatureVerificationResult,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) {
     guard case .failure(.unableToValidateSigner) = result else {

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -274,7 +274,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         requester: @autoclosure () -> some OCSPRequester,
         validationTime: Date? = nil,
         expectedQueryCount: Int = 1,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         switch soft {
@@ -328,7 +328,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         requester: some OCSPRequester,
         expectedQueryCount: Int = 1,
         validationTime: Date? = nil,
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         var policy = OCSPVerifierPolicy(
@@ -370,7 +370,7 @@ final class OCSPVerifierPolicyTests: XCTestCase {
         expectedQueryCount: Int = 1,
         validationTime: Date? = nil,
 
-        file: StaticString = #file,
+        file: StaticString = #filePath,
         line: UInt = #line
     ) async {
         var policy = OCSPVerifierPolicy(

--- a/Tests/X509Tests/ServerIdentityPolicyTests.swift
+++ b/Tests/X509Tests/ServerIdentityPolicyTests.swift
@@ -636,7 +636,7 @@ extension ASN1OctetString {
 
 private func XCTAssertValidCertificate(
     _ verifier: @autoclosure () async throws -> VerificationResult,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) async rethrows {
     let result = try await verifier()
@@ -647,7 +647,7 @@ private func XCTAssertValidCertificate(
 
 private func XCTAssertInvalidCertificate(
     _ verifier: @autoclosure () async throws -> VerificationResult,
-    file: StaticString = #file,
+    file: StaticString = #filePath,
     line: UInt = #line
 ) async rethrows {
     let result = try await verifier()


### PR DESCRIPTION
Motivation:

This is consistent with what underlying assert does. Swift 6 warns about this mismatch

Modifications:

Use filePath for test assert location

Result:

Consistency in test assert location reportin