### PR TITLE
Avoid the macOS requirement.

### DIFF
--- a/Sources/X509/SecKeyWrapper.swift
+++ b/Sources/X509/SecKeyWrapper.swift
@@ -119,7 +119,7 @@ extension Certificate.PrivateKey {
                 )
             }
 
-            if privateKeyType == (kSecAttrKeyTypeECDSA as String) {
+            if privateKeyType == (kSecAttrKeyTypeECSECPrimeRandom as String) {
                 let keySize = attributes[kSecAttrKeySizeInBits as String] as? Int ?? -1
 
                 if keySize == 256 {

--- a/Tests/X509Tests/SecKeyWrapperTests.swift
+++ b/Tests/X509Tests/SecKeyWrapperTests.swift
@@ -38,7 +38,12 @@ final class SecKeyWrapperTests: XCTestCase {
         )
 
         // eliptic curves
-        for keyType in [kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyTypeEC, kSecAttrKeyTypeECDSA] {
+        var keyTypes = [kSecAttrKeyTypeECSECPrimeRandom, kSecAttrKeyTypeEC]
+        #if os(macOS)
+        keyTypes.append(kSecAttrKeyTypeECDSA)
+        #endif
+
+        for keyType in keyTypes {
             for keySize in [256, 384] {
                 for useSEP in [true, false] {
                     keys.append(
@@ -52,9 +57,11 @@ final class SecKeyWrapperTests: XCTestCase {
                 }
             }
         }
+
         return keys
     }
 
+    @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
     func testPEMExport() throws {
         for candidate in try generateCandidateKeys() {
             try XCTContext.runActivity(named: "Testing \(candidate.type) key (size: \(candidate.keySize))") { _ in


### PR DESCRIPTION
It seems that `kSecAttrKeyTypeECDSA` is not available on non-mac platforms. This patch amends the code to run appropriately on those platforms.

I've validated this works by testing in the iOS simulator. I'll need to validate the other platforms as well, but that'll take a little while longer, so I'll make a follow-up patch if this turns out to be insufficient.

Resolves #202.