### PR TITLE
Enable MemberImportVisibility check on all targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -90,3 +90,14 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-asn1"),
     ]
 }
+
+// ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
+for target in package.targets {
+    if target.type != .plugin {
+        var settings = target.swiftSettings ?? []
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0444-member-import-visibility.md
+        settings.append(.enableUpcomingFeature("MemberImportVisibility"))
+        target.swiftSettings = settings
+    }
+}
+// --- END: STANDARD CROSS-REPO SETTINGS DO NOT EDIT --- //

--- a/Tests/X509Tests/ExtendedKeyUsageTests.swift
+++ b/Tests/X509Tests/ExtendedKeyUsageTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import SwiftASN1
 import X509
 
 final class ExtendedKeyUsageTests: XCTestCase {

--- a/Tests/X509Tests/ExtensionBuilderTests.swift
+++ b/Tests/X509Tests/ExtensionBuilderTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import XCTest
+import SwiftASN1
 import X509
 
 final class ExtensionBuilderTests: XCTestCase {


### PR DESCRIPTION
Enable MemberImportVisibility check on all targets. Use a standard string header and footer to bracket the new block for ease of updating in the future with scripts.