### PR TITLE
Enable strict concurrency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "-Xswiftc --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,9 +13,9 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc --explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -24,9 +24,9 @@ jobs:
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 
   benchmarks:
     name: Benchmarks

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "-Xswiftc --explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,7 +23,7 @@ jobs:
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
       linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
-      linux_5_10_arguments_override: "-Xswiftc --explicit-target-dependency-import-check error"
+      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_6_0_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project
@@ -89,6 +89,12 @@ if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
         .package(path: "../swift-crypto"),
         .package(path: "../swift-asn1"),
     ]
+}
+
+for target in package.targets {
+    var settings = target.swiftSettings ?? []
+    settings.append(.enableExperimentalFeature("StrictConcurrency=complete"))
+    target.swiftSettings = settings
 }
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //

--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ a default verifier and a number of built-in verifier policies.
 
 ## Supported Swift Versions
 
-This library was introduced with support for Swift 5.7 or later. This library will
-support the latest stable Swift version and the two versions prior.
+This library will support the latest stable Swift version and the two versions prior.
 
 ## Getting Started
 

--- a/Sources/X509/SecKeyWrapper.swift
+++ b/Sources/X509/SecKeyWrapper.swift
@@ -66,7 +66,7 @@ extension Certificate.PrivateKey {
 
         @usableFromInline
         static func keyAttributes(key: SecKey) throws -> [String: any Sendable] {
-            guard let attributes = SecKeyCopyAttributes(key) as? [CFString: Any] else {
+            guard let attributes = SecKeyCopyAttributes(key) as? [CFString: any Sendable] else {
                 throw CertificateError.unsupportedPrivateKey(
                     reason: "cannot copy SecKey attributes"
                 )

--- a/Tests/X509Tests/SecKeyWrapperTests.swift
+++ b/Tests/X509Tests/SecKeyWrapperTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 @_spi(Testing) @testable import X509
 
 #if canImport(Darwin)
@@ -62,9 +62,9 @@ final class SecKeyWrapperTests: XCTestCase {
     }
 
     @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, *)
-    func testPEMExport() throws {
+    func testPEMExport() async throws {
         for candidate in try generateCandidateKeys() {
-            try XCTContext.runActivity(named: "Testing \(candidate.type) key (size: \(candidate.keySize))") { _ in
+            try await XCTContext.runActivity(named: "Testing \(candidate.type) key (size: \(candidate.keySize))") { _ in
                 let secKeyWrapper = try Certificate.PrivateKey.SecKeyWrapper(key: candidate.key)
 
                 if !candidate.sep {

--- a/Tests/X509Tests/SecKeyWrapperTests.swift
+++ b/Tests/X509Tests/SecKeyWrapperTests.swift
@@ -12,8 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import XCTest
+import XCTest
 @_spi(Testing) @testable import X509
+#if canImport(Darwin)
+@preconcurrency import Security
+#endif
 
 #if canImport(Darwin)
 final class SecKeyWrapperTests: XCTestCase {

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import XCTest
+@preconcurrency import XCTest
 @preconcurrency import Crypto
 import _CryptoExtras
 import SwiftASN1

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -12,11 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
-@preconcurrency import XCTest
+import XCTest
 @preconcurrency import Crypto
 import _CryptoExtras
 import SwiftASN1
 @testable import X509
+#if canImport(Darwin)
+@preconcurrency import Security
+#endif
 
 final class SignatureTests: XCTestCase {
     static let now = Date()


### PR DESCRIPTION
Motivation:

To catch potential data races at build time.

Modifications:

- Bump Swift tools version from 5.8 to 5.9 in Package.swift.
- Enable strict concurrency in Package.swift.
- Adjust the documentation section on the supported Swift versions.
- Implement minor fixes for the surfaced strict concurrency warnings.
- Add `-require-explicit-sendable` to the 6.0, nightly 6.0 and nightly main CI checks.

Result:

Strict concurrency adoption.