### PR TITLE
Tag CMS signer identifier implicitly

### DIFF
--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -1134,6 +1134,19 @@ final class CMSTests: XCTestCase {
         }
         XCTAssertInvalidCMSBlock(isValidSignature)
     }
+
+    func testSubjectKeyIdentifierIsCorrectlyImplicitylyTagged() throws {
+        let implicitlyTaggedSki: [UInt8] = [
+            0x80,  // Context-specific tag [0]
+            0x04,  // Length
+            0x0a, 0x14, 0x1e, 0x28
+        ]
+
+        XCTAssertEqual(
+            try CMSSignerIdentifier(derEncoded: implicitlyTaggedSki),
+            CMSSignerIdentifier.subjectKeyIdentifier(.init(keyIdentifier: [10, 20, 30, 40]))
+        )
+    }
 }
 
 extension DERSerializable {

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -1139,7 +1139,7 @@ final class CMSTests: XCTestCase {
         let implicitlyTaggedSki: [UInt8] = [
             0x80,  // Context-specific tag [0]
             0x04,  // Length
-            0x0a, 0x14, 0x1e, 0x28
+            0x0a, 0x14, 0x1e, 0x28,
         ]
 
         XCTAssertEqual(


### PR DESCRIPTION
As pointed out in https://github.com/apple/swift-certificates/issues/203, the SignerIdentifier in PKCS#7 CMS should be implicitly tagged while the currently swift-certificates explicitly tags it. This PR contains changes for SignerIdentifier of SubjectKeyIdentifier type to be implicitly tagged.

[RFC 5652 § 12.1](https://datatracker.ietf.org/doc/html/rfc5652#section-12.1):
```
SignerIdentifier ::= CHOICE {
  issuerAndSerialNumber IssuerAndSerialNumber,
  subjectKeyIdentifier [0] SubjectKeyIdentifier }
  ```
  
  
  Resolves: https://github.com/apple/swift-certificates/issues/203