### PR TITLE
Use proper hash when computing message digest in signed attributes

### DIFF
--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -43,6 +43,22 @@ enum Digest {
     }
 }
 
+extension Digest: Sequence {
+    @usableFromInline
+    func makeIterator() -> Array<UInt8>.Iterator {
+        switch self {
+        case .insecureSHA1(let sha1):
+            return sha1.makeIterator()
+        case .sha256(let sha256):
+            return sha256.makeIterator()
+        case .sha384(let sha384):
+            return sha384.makeIterator()
+        case .sha512(let sha512):
+            return sha512.makeIterator()
+        }
+    }
+}
+
 // MARK: Public key operations
 
 extension P256.Signing.PublicKey {

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -45,7 +45,7 @@ enum Digest {
 
 extension Digest: Sequence {
     @usableFromInline
-    func makeIterator() -> Array<UInt8>.Iterator {
+    func makeIterator() -> some IteratorProtocol<UInt8> {
         switch self {
         case .insecureSHA1(let sha1):
             return sha1.makeIterator()

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -1052,6 +1052,25 @@ final class CMSTests: XCTestCase {
         XCTAssertValidSignature(isValidSignature)
     }
 
+    func testSigningWithSigningTimeSignedAttrAndSHA512() async throws {
+        let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let signature = try CMS.sign(
+            data,
+            signatureAlgorithm: .ecdsaWithSHA512,
+            certificate: Self.leaf1Cert,
+            privateKey: Self.leaf1Key,
+            signingTime: Date()
+        )
+        let isValidSignature = await CMS.isValidSignature(
+            dataBytes: data,
+            signatureBytes: signature,
+            trustRoots: CertificateStore([Self.rootCert])
+        ) {
+            Self.defaultPolicies
+        }
+        XCTAssertValidSignature(isValidSignature)
+    }
+
     func testSigningAttachedWithSigningTimeSignedAttr() async throws {
         let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         let signature = try CMS.sign(


### PR DESCRIPTION
Per [RFC 5652 § 11.2](https://datatracker.ietf.org/doc/html/rfc5652#section-11.2):

"For signed-data, the message digest is computed using the signer's message digest algorithm."

Currently, when computing the signed attributes' message digest, `CMS.sign` assumes the digest algorithm is SHA256, which is incorrect. The behavior of `CMS.isValid` is already correct and doesn't need updating. I've made `Digest` conform to `Sequence` to facilitate the conversion/comparison of the message digest.