### PR TITLE
Replace platforms from Package manifest with availability guards

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", "2.5.0"..<"4.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", from: "3.11.2"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0"),
     ]
 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -18,12 +18,6 @@ import class Foundation.ProcessInfo
 
 let package = Package(
     name: "swift-certificates",
-    platforms: [
-        .macOS(.v10_15),
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
-    ],
     products: [
         .library(
             name: "X509",

--- a/Sources/X509/CSR/CSRAttribute.swift
+++ b/Sources/X509/CSR/CSRAttribute.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest {
     /// A general-purpose representation of a ``CertificateSigningRequest`` attribute.
     ///
@@ -47,6 +48,7 @@ extension CertificateSigningRequest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attribute: Hashable {
     @inlinable
     public static func == (lhs: CertificateSigningRequest.Attribute, rhs: CertificateSigningRequest.Attribute) -> Bool {
@@ -78,8 +80,10 @@ extension CertificateSigningRequest.Attribute: Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attribute: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attribute: CustomStringConvertible {
     public var description: String {
         return "Attribute(oid: \(self.oid), values: \(self.values))"
@@ -90,6 +94,7 @@ extension CertificateSigningRequest.Attribute: CustomStringConvertible {
 //      type   ATTRIBUTE.&id({IOSet}),
 //      values SET SIZE(1..MAX) OF ATTRIBUTE.&Type({IOSet}{@type})
 // }
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attribute: DERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: ASN1Identifier {

--- a/Sources/X509/CSR/CSRAttributes.swift
+++ b/Sources/X509/CSR/CSRAttributes.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest {
     /// A representation of the additional attributes on a certificate signing request.
     ///
@@ -57,6 +58,7 @@ extension CertificateSigningRequest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attributes: Hashable {
     @inlinable
     public static func == (lhs: CertificateSigningRequest.Attributes, rhs: CertificateSigningRequest.Attributes) -> Bool
@@ -85,8 +87,10 @@ extension CertificateSigningRequest.Attributes: Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attributes: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attributes: RandomAccessCollection {
     @inlinable
     public init() {
@@ -136,6 +140,7 @@ extension CertificateSigningRequest.Attributes: RandomAccessCollection {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attributes: CustomStringConvertible {
     @inlinable
     public var description: String {
@@ -144,6 +149,7 @@ extension CertificateSigningRequest.Attributes: CustomStringConvertible {
 }
 
 // MARK: Helpers for specific extensions
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attributes {
     /// Look up a specific attribute by its OID.
     ///

--- a/Sources/X509/CSR/CSRVersion.swift
+++ b/Sources/X509/CSR/CSRVersion.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest {
     /// The version of the CSR format.
     ///
@@ -30,10 +31,13 @@ extension CertificateSigningRequest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Version: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Version: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Version: Comparable {
     @inlinable
     public static func < (lhs: CertificateSigningRequest.Version, rhs: CertificateSigningRequest.Version) -> Bool {
@@ -41,6 +45,7 @@ extension CertificateSigningRequest.Version: Comparable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Version: CustomStringConvertible {
     public var description: String {
         switch self {

--- a/Sources/X509/CSR/CertificateSigningRequest.swift
+++ b/Sources/X509/CSR/CertificateSigningRequest.swift
@@ -24,6 +24,7 @@ import SwiftASN1
 /// Certificate Signing Requests are used to encapsulate information that an end-entity would like
 /// encapsulated in a certificate. They are typically processed by Certificate Authorities and turned
 /// into certificates signed by that CA.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct CertificateSigningRequest {
     /// The version of this CSR.
     ///
@@ -199,10 +200,13 @@ public struct CertificateSigningRequest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest: CustomStringConvertible {
     @inlinable
     public var description: String {
@@ -211,6 +215,7 @@ extension CertificateSigningRequest: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest: DERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: ASN1Identifier {
@@ -250,6 +255,7 @@ extension CertificateSigningRequest: DERImplicitlyTaggable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest: PEMRepresentable {
     @inlinable
     public static var defaultPEMDiscriminator: String {

--- a/Sources/X509/CSR/CertificationRequestInfo.swift
+++ b/Sources/X509/CSR/CertificationRequestInfo.swift
@@ -14,6 +14,7 @@
 import SwiftASN1
 
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct CertificationRequestInfo {
     @usableFromInline
     var version: CertificateSigningRequest.Version
@@ -41,8 +42,10 @@ struct CertificationRequestInfo {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificationRequestInfo: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificationRequestInfo: Sendable {}
 
 // CertificationRequestInfo ::= SEQUENCE {
@@ -51,6 +54,7 @@ extension CertificationRequestInfo: Sendable {}
 //      subjectPKInfo SubjectPublicKeyInfo{{ PKInfoAlgorithms }},
 //      attributes    [0] Attributes{{ CRIAttributes }}
 // }
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificationRequestInfo: DERImplicitlyTaggable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {

--- a/Sources/X509/CSR/ExtensionRequest.swift
+++ b/Sources/X509/CSR/ExtensionRequest.swift
@@ -18,6 +18,7 @@ import SwiftASN1
 ///
 /// X.509 certificates contain a number of extensions. This attribute includes the extensions that the
 /// subscriber wishes the CA to embed into the certificate.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct ExtensionRequest: Hashable, Sendable {
     /// The underlying extensions.
     public var extensions: Certificate.Extensions
@@ -55,6 +56,7 @@ public struct ExtensionRequest: Hashable, Sendable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateSigningRequest.Attribute {
     /// Wrap an ``ExtensionRequest`` into a ``CertificateSigningRequest/Attribute``.
     ///
@@ -70,6 +72,7 @@ extension CertificateSigningRequest.Attribute {
 }
 
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct ExtensionRequestAttribute: Hashable, Sendable, DERImplicitlyTaggable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {

--- a/Sources/X509/Certificate.swift
+++ b/Sources/X509/Certificate.swift
@@ -69,6 +69,7 @@ import SwiftASN1
 /// An instance of ``Certificate`` can be created from ``Security/SecCertificate`` (from the ``Security`` framework) with ``Certificate/init(_:)``.
 /// The opposite, that is, creating an instance of ``Security/SecCertificate`` from ``Certificate``, can be achieved with ``Security/SecCertificate/makeWithCertificate(_:)``.
 #endif
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct Certificate {
     /// The X.509 version of this certificate.
     ///
@@ -279,10 +280,13 @@ public struct Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate: CustomStringConvertible {
     public var description: String {
         """
@@ -301,6 +305,7 @@ extension Certificate: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate: DERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: ASN1Identifier {
@@ -350,6 +355,7 @@ extension DER.Serializer {
 
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate: PEMRepresentable {
     @inlinable
     public static var defaultPEMDiscriminator: String { "CERTIFICATE" }
@@ -357,6 +363,8 @@ extension Certificate: PEMRepresentable {
 
 #if canImport(Security)
 import Security
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// Creates an instance of ``Certificate`` from ``Security/SecCertificate``.
     /// To create an instance of ``Security/SecCertificate``, use ``Security/SecCertificate/makeWithCertificate(_:)`` instead.
@@ -366,6 +374,7 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecCertificate {
     /// Creates an instance of ``Security/SecCertificate`` from ``Certificate``.
     /// To create an instance of ``Certificate``, use ``Certificate/init(_:)`` instead.

--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -21,6 +21,7 @@ import Foundation
 @preconcurrency import Crypto
 import _CryptoExtras
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A private key that can be used with a certificate.
     ///
@@ -175,10 +176,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PrivateKey: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PrivateKey: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PrivateKey: CustomStringConvertible {
     public var description: String {
         switch self.backing {
@@ -202,6 +206,7 @@ extension Certificate.PrivateKey: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PrivateKey {
     @usableFromInline
     enum BackingPrivateKey: Hashable, Sendable {

--- a/Sources/X509/CertificatePublicKey.swift
+++ b/Sources/X509/CertificatePublicKey.swift
@@ -21,6 +21,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A public key that can be used with a certificate.
     ///
@@ -100,6 +101,7 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey {
     /// Confirms that `signature` is a valid signature for `certificate`, created by the
     /// private key associated with this public key.
@@ -156,10 +158,13 @@ extension Certificate.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey: CustomStringConvertible {
     public var description: String {
         switch self.backing {
@@ -177,6 +182,7 @@ extension Certificate.PublicKey: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey {
     @usableFromInline
     enum BackingPublicKey: Hashable, Sendable {
@@ -227,6 +233,7 @@ extension Certificate.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SubjectPublicKeyInfo {
     @inlinable
     init(_ publicKey: Certificate.PublicKey) {
@@ -256,6 +263,7 @@ extension SubjectPublicKeyInfo {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey {
     /// The byte array of the public key used in the certificate.
     ///
@@ -266,6 +274,7 @@ extension Certificate.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P256.Signing.PublicKey {
     /// Create a P256 Public Key from a given ``Certificate/PublicKey-swift.struct``.
     ///
@@ -281,6 +290,7 @@ extension P256.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P384.Signing.PublicKey {
     /// Create a P384 Public Key from a given ``Certificate/PublicKey-swift.struct``.
     ///
@@ -296,6 +306,7 @@ extension P384.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P521.Signing.PublicKey {
     /// Create a P521 Public Key from a given ``Certificate/PublicKey-swift.struct``.
     ///
@@ -311,6 +322,7 @@ extension P521.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension _RSA.Signing.PublicKey {
     /// Create an RSA Public Key from a given ``Certificate/PublicKey-swift.struct``.
     ///
@@ -326,6 +338,7 @@ extension _RSA.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Curve25519.Signing.PublicKey {
     /// Create a Curve25519 Public Key from a given ``Certificate/PublicKey-swift.struct``.
     ///
@@ -341,6 +354,7 @@ extension Curve25519.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey: PEMParseable, PEMSerializable {
     @inlinable
     public static var defaultPEMDiscriminator: String {
@@ -348,6 +362,7 @@ extension Certificate.PublicKey: PEMParseable, PEMSerializable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PublicKey: DERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: SwiftASN1.ASN1Identifier {

--- a/Sources/X509/CertificateSerialNumber.swift
+++ b/Sources/X509/CertificateSerialNumber.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A number that uniquely identifies a certificate issued by a specific
     /// certificate authority.
@@ -86,10 +87,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SerialNumber: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SerialNumber: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SerialNumber: CustomStringConvertible {
     public var description: String {
         return self.bytes.lazy.map { String($0, radix: 16) }.joined(separator: ":")

--- a/Sources/X509/CertificateVersion.swift
+++ b/Sources/X509/CertificateVersion.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// The X.509 certificate version.
     ///
@@ -35,10 +36,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Version: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Version: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Version: Comparable {
     @inlinable
     public static func < (lhs: Certificate.Version, rhs: Certificate.Version) -> Bool {
@@ -46,6 +50,7 @@ extension Certificate.Version: Comparable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Version: CustomStringConvertible {
     public var description: String {
         switch self {

--- a/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSContentInfo.swift
@@ -97,6 +97,7 @@ struct CMSContentInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, S
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CMSContentInfo {
     @inlinable
     init(_ signedData: CMSSignedData) throws {

--- a/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSIssuerAndSerialNumber.swift
@@ -23,6 +23,7 @@ import SwiftASN1
 /// The definition of `Name` is taken from X.501 [X.501-88], and the
 /// definition of `CertificateSerialNumber` is taken from X.509 [X.509-97].
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct CMSIssuerAndSerialNumber: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -19,6 +19,7 @@ import Foundation
 import SwiftASN1
 import Crypto
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum CMS {
     @_spi(CMS)
     @inlinable
@@ -487,6 +488,7 @@ public enum CMS {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Array where Element == Certificate {
     @usableFromInline
     func certificate(signerInfo: CMSSignerInfo) throws -> Certificate? {
@@ -504,6 +506,7 @@ extension Array where Element == Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Signature {
     @inlinable
     init(signatureAlgorithm: Certificate.SignatureAlgorithm, signatureBytes: ASN1OctetString) throws {

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
@@ -27,6 +27,7 @@ import Foundation
 /// view over a CMS signed-data payload. It also abstracts the specific ASN.1 layout of the
 /// signature.
 @_spi(CMS)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct CMSSignature: Sendable, Hashable {
     @usableFromInline
     let base: CMSSignedData
@@ -50,6 +51,7 @@ public struct CMSSignature: Sendable, Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CMSSignature: DERImplicitlyTaggable, BERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: ASN1Identifier {
@@ -84,6 +86,7 @@ extension CMSSignature: DERImplicitlyTaggable, BERImplicitlyTaggable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CMSSignature {
     /// One of the "signers" that produced a given CMS block.
     ///

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignedData.swift
@@ -42,6 +42,7 @@ import SwiftASN1
 /// ```
 /// - Note: At the moment we don't support `crls` (`RevocationInfoChoices`)
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct CMSSignedData: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerIdentifier.swift
@@ -21,6 +21,7 @@ import SwiftASN1
 ///   subjectKeyIdentifier [0] SubjectKeyIdentifier }
 ///  ```
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 enum CMSSignerIdentifier: DERParseable, BERParseable, DERSerializable, BERSerializable, Hashable, Sendable {
     @usableFromInline
     static let skiIdentifier = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -38,6 +38,7 @@ import SwiftASN1
 /// then the `version` MUST be 1.  If the `SignerIdentifier` is `subjectKeyIdentifier`,
 /// then the `version` MUST be 3.
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
     @usableFromInline
     enum Error: Swift.Error {
@@ -227,6 +228,7 @@ struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Se
 }
 
 // MARK: - SignedAttrs
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CMSSignerInfo {
     @inlinable
     /// Returns the  signedAttrs in DER encoded form by re-serializes the parsed signedAttrs, or immediately returning

--- a/Sources/X509/Curve25519+DER.swift
+++ b/Sources/X509/Curve25519+DER.swift
@@ -20,6 +20,7 @@ import Foundation
 import SwiftASN1
 import Crypto
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Curve25519.Signing.PrivateKey {
     @inlinable
     init(pkcs8Key: PKCS8PrivateKey) throws {

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -20,6 +20,7 @@ import Foundation
 import Crypto
 
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 enum Digest {
     case insecureSHA1(Insecure.SHA1Digest)
     case sha256(SHA256Digest)
@@ -46,6 +47,7 @@ enum Digest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Digest: Sequence {
     @usableFromInline
     func makeIterator() -> some IteratorProtocol<UInt8> {

--- a/Sources/X509/Extension Types/AuthorityInformationAccess.swift
+++ b/Sources/X509/Extension Types/AuthorityInformationAccess.swift
@@ -45,6 +45,7 @@ public struct AuthorityInformationAccess {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.authorityInformationAccess`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.authorityInformationAccess else {
             throw CertificateError.incorrectOIDForExtension(
@@ -218,6 +219,7 @@ extension AuthorityInformationAccess.AccessDescription.AccessMethod.Backing: Has
 
 extension AuthorityInformationAccess.AccessDescription.AccessMethod.Backing: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this AIA extension.
     ///
@@ -237,6 +239,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityInformationAccess: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/AuthorityKeyIdentifier.swift
+++ b/Sources/X509/Extension Types/AuthorityKeyIdentifier.swift
@@ -16,6 +16,7 @@ import SwiftASN1
 
 /// Provides information about the public key corresponding to the private key that was
 /// used to sign a specific certificate.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct AuthorityKeyIdentifier {
     /// An opaque sequence of bytes uniquely derived from the public key of the issuing
     /// CA.
@@ -69,10 +70,13 @@ public struct AuthorityKeyIdentifier {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityKeyIdentifier: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityKeyIdentifier: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityKeyIdentifier: CustomStringConvertible {
     public var description: String {
         var elements: [String] = []
@@ -93,12 +97,14 @@ extension AuthorityKeyIdentifier: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityKeyIdentifier: CustomDebugStringConvertible {
     public var debugDescription: String {
         "AuthorityKeyIdentifier(\(String(describing: self)))"
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this AKI extension.
     ///
@@ -118,6 +124,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AuthorityKeyIdentifier: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)
@@ -153,6 +160,7 @@ struct AuthorityKeyIdentifierValue: DERImplicitlyTaggable {
     }
 
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     init(_ aki: AuthorityKeyIdentifier) {
         self.keyIdentifier = aki.keyIdentifier.map { ASN1OctetString(contentBytes: $0) }
         self.authorityCertIssuer = aki.authorityCertIssuer

--- a/Sources/X509/Extension Types/BasicConstraints.swift
+++ b/Sources/X509/Extension Types/BasicConstraints.swift
@@ -36,6 +36,7 @@ public enum BasicConstraints {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.basicConstraints`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.basicConstraints else {
             throw CertificateError.incorrectOIDForExtension(
@@ -75,6 +76,7 @@ extension BasicConstraints: CustomDebugStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Basic Constraints extension.
     ///
@@ -90,6 +92,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension BasicConstraints: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/ExtendedKeyUsage.swift
+++ b/Sources/X509/Extension Types/ExtendedKeyUsage.swift
@@ -56,6 +56,7 @@ public struct ExtendedKeyUsage {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.extendedKeyUsage`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.extendedKeyUsage else {
             throw CertificateError.incorrectOIDForExtension(
@@ -319,6 +320,7 @@ extension ExtendedKeyUsage.Usage.Backing: Hashable {}
 
 extension ExtendedKeyUsage.Usage.Backing: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Extended Key Usage extension.
     ///
@@ -334,6 +336,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ExtendedKeyUsage: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/KeyUsage.swift
+++ b/Sources/X509/Extension Types/KeyUsage.swift
@@ -87,6 +87,7 @@ public struct KeyUsage {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.keyUsage`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.keyUsage else {
             throw CertificateError.incorrectOIDForExtension(
@@ -320,6 +321,7 @@ extension KeyUsage: CustomDebugStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Key Usage extension.
     ///
@@ -335,6 +337,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension KeyUsage: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/NameConstraints.swift
+++ b/Sources/X509/Extension Types/NameConstraints.swift
@@ -662,6 +662,7 @@ public struct NameConstraints {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.nameConstraints`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.nameConstraints else {
             throw CertificateError.incorrectOIDForExtension(
@@ -717,6 +718,7 @@ extension NameConstraints: CustomDebugStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Name Constraints extension.
     ///
@@ -732,6 +734,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NameConstraints: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/SubjectAlternativeName.swift
+++ b/Sources/X509/Extension Types/SubjectAlternativeName.swift
@@ -45,6 +45,7 @@ public struct SubjectAlternativeNames {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.subjectAlternativeName`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.subjectAlternativeName else {
             throw CertificateError.incorrectOIDForExtension(
@@ -101,6 +102,7 @@ extension SubjectAlternativeNames: RandomAccessCollection, MutableCollection, Ra
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Subject Alternative Name extension.
     ///
@@ -120,6 +122,7 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SubjectAlternativeNames: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)

--- a/Sources/X509/Extension Types/SubjectKeyIdentifier.swift
+++ b/Sources/X509/Extension Types/SubjectKeyIdentifier.swift
@@ -40,6 +40,7 @@ public struct SubjectKeyIdentifier {
     /// - Throws: if the ``Certificate/Extension/oid`` is not equal to
     ///     `ASN1ObjectIdentifier.X509ExtensionID.subjectKeyIdentifier`.
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .X509ExtensionID.subjectKeyIdentifier else {
             throw CertificateError.incorrectOIDForExtension(
@@ -68,6 +69,7 @@ extension SubjectKeyIdentifier: CustomDebugStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Subject Key Identifier extension.
     ///
@@ -87,12 +89,14 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SubjectKeyIdentifier: CertificateExtensionConvertible {
     public func makeCertificateExtension() throws -> Certificate.Extension {
         return try .init(self, critical: false)
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SubjectKeyIdentifier {
     /// Construct a ``SubjectKeyIdentifier`` by hashing the given `publicKey` with SHA-1 according to RFC 5280 Section 4.2.1.2.
     /// - Parameter publicKey: the public key which will be hashed

--- a/Sources/X509/Extension.swift
+++ b/Sources/X509/Extension.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A general-purpose representation of a specific X.509 extension.
     ///
@@ -67,10 +68,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension: CustomStringConvertible {
     public var description: String {
         if let knownExtension = try? AuthorityInformationAccess(self) {
@@ -101,6 +105,7 @@ extension Certificate.Extension: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension: DERImplicitlyTaggable {
     @inlinable
     public static var defaultIdentifier: ASN1Identifier {
@@ -132,6 +137,7 @@ extension Certificate.Extension: DERImplicitlyTaggable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension: CertificateExtensionConvertible {
     public func makeCertificateExtension() -> Certificate.Extension {
         self

--- a/Sources/X509/Extensions.swift
+++ b/Sources/X509/Extensions.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A representation of a collection of X.509 extensions.
     ///
@@ -143,10 +144,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions: RandomAccessCollection {
     /// Produce a new empty Extensions container.
     @inlinable
@@ -173,6 +177,7 @@ extension Certificate.Extensions: RandomAccessCollection {
 }
 
 // MARK: Modifying methods
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions {
 
     /// Append a new ``Certificate/Extension`` into this set of ``Certificate/Extensions-swift.struct``.
@@ -222,6 +227,7 @@ extension Certificate.Extensions {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions: CustomStringConvertible {
     @inlinable
     public var description: String {
@@ -232,6 +238,7 @@ extension Certificate.Extensions: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions: CustomDebugStringConvertible {
     public var debugDescription: String {
         "[\(String(describing: self))]"
@@ -239,6 +246,7 @@ extension Certificate.Extensions: CustomDebugStringConvertible {
 }
 
 // MARK: Helpers for specific extensions
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions {
     /// Look up a specific extension by its OID.
     ///

--- a/Sources/X509/ExtensionsBuilder.swift
+++ b/Sources/X509/ExtensionsBuilder.swift
@@ -39,6 +39,7 @@
 ///
 /// Users are also able to mark specific extensions as critical by using the ``Critical`` helper type.
 @resultBuilder
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct ExtensionsBuilder {
     @inlinable
     public static func buildExpression<Extension: CertificateExtensionConvertible>(
@@ -118,6 +119,7 @@ public struct ExtensionsBuilder {
 /// Note that for most extension types, the returned ``Certificate/Extension`` should have its
 /// ``Certificate/Extension/critical`` value set to `false`. This allows the ``Critical`` helper
 /// type to fulfill its function as expected.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public protocol CertificateExtensionConvertible {
     /// Convert the value into a ``Certificate/Extension``.
     func makeCertificateExtension() throws -> Certificate.Extension
@@ -127,6 +129,7 @@ public protocol CertificateExtensionConvertible {
 ///
 /// This type is used only within the ``ExtensionsBuilder`` DSL to mark extensions as critical.
 @frozen
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct Critical<BaseExtension: CertificateExtensionConvertible>: CertificateExtensionConvertible {
     /// The ``CertificateExtensionConvertible`` backing this value.
     public var base: BaseExtension

--- a/Sources/X509/OCSP/BasicOCSPResponse.swift
+++ b/Sources/X509/OCSP/BasicOCSPResponse.swift
@@ -77,6 +77,7 @@ import SwiftASN1
 /// ```
 ///
 /// This type is generic because our different backends want to use different bignum representations.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct BasicOCSPResponse: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPCertID.swift
+++ b/Sources/X509/OCSP/OCSPCertID.swift
@@ -26,6 +26,7 @@ import SwiftASN1
 /// CertificateSerialNumber ::= INTEGER
 /// ```
 ///
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPCertID: DERImplicitlyTaggable, Hashable {
     var hashAlgorithm: AlgorithmIdentifier
 

--- a/Sources/X509/OCSP/OCSPNonce.swift
+++ b/Sources/X509/OCSP/OCSPNonce.swift
@@ -34,6 +34,7 @@ struct OCSPNonce: DERImplicitlyTaggable, Hashable, Sendable {
         self.rawValue = .init(contentBytes: generator.bytes(count: 32))
     }
 
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     init(_ ext: Certificate.Extension) throws {
         guard ext.oid == .OCSPExtensionID.nonceIdentifier else {
             throw CertificateError.incorrectOIDForExtension(
@@ -62,6 +63,7 @@ extension ASN1ObjectIdentifier.OCSPExtensionID {
     static let nonceIdentifier: ASN1ObjectIdentifier = [1, 3, 6, 1, 5, 5, 7, 48, 1, 2]
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extension {
     /// Construct an opaque ``Certificate/Extension`` from this Key Usage extension.
     ///
@@ -75,12 +77,14 @@ extension Certificate.Extension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPNonce: CertificateExtensionConvertible {
     func makeCertificateExtension() throws -> Certificate.Extension {
         try .init(self, critical: false)
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions {
     var ocspNonce: OCSPNonce? {
         get throws {

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -84,6 +84,7 @@ extension ASN1ObjectIdentifier {
     static let sha1NoSign: Self = [1, 3, 14, 3, 2, 26]
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPResponderSigningPolicy: VerifierPolicy {
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
@@ -122,6 +123,7 @@ struct OCSPResponderSigningPolicy: VerifierPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 enum OCSPRequestHashAlgorithm {
     case insecureSha1
     // we can't yet enable sha256 by default but we want in the future
@@ -182,6 +184,7 @@ public struct OCSPFailureMode: Hashable, Sendable {
     var storage: Storage
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy {
     public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
@@ -247,6 +250,7 @@ public struct OCSPVerifierPolicy<Requester: OCSPRequester>: VerifierPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPVerifierPolicy.Storage {
 
     /// Returns `.meetsPolicy` if the `failureMode` is set to `.soft`.
@@ -540,6 +544,7 @@ extension OCSPVerifierPolicy.Storage {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPCertID {
     init(hashAlgorithm: OCSPRequestHashAlgorithm, certificate: Certificate, issuer: Certificate) throws {
         self.init(
@@ -551,6 +556,7 @@ extension OCSPCertID {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPRequest {
     init(certID: OCSPCertID, nonce: OCSPNonce?) throws {
         self.init(
@@ -569,6 +575,7 @@ extension OCSPRequest {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPResponseData {
     /// 1 hour to address time zone bugs and 15 min for clock skew of the responder/requester
     static let defaultTrustTimeLeeway: TimeInterval = 4500.0
@@ -590,6 +597,7 @@ extension OCSPResponseData {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPSingleResponse {
 
     func verifyTime(
@@ -626,6 +634,7 @@ extension OCSPSingleResponse {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     fileprivate func matches(_ responderID: ResponderID) -> Bool {
         switch responderID {
@@ -643,6 +652,7 @@ extension Certificate {
 ///   - maxDuration: max execution duration in seconds of `operation`
 ///   - operation: the task to start and cancel after `maxDuration` seconds
 /// - Returns: the result of `operation`
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 private func withTimeout<Result: Sendable>(
     _ maxDuration: TimeInterval,
     operation: @escaping @Sendable () async -> Result

--- a/Sources/X509/OCSP/OCSPRequest.swift
+++ b/Sources/X509/OCSP/OCSPRequest.swift
@@ -20,6 +20,7 @@ import SwiftASN1
 ///    tbsRequest              TBSRequest,
 ///    optionalSignature   [0] EXPLICIT Signature OPTIONAL }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPRequest: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPResponse.swift
+++ b/Sources/X509/OCSP/OCSPResponse.swift
@@ -23,6 +23,7 @@ import SwiftASN1
 ///
 /// ```
 ///
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 enum OCSPResponse: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence
@@ -96,6 +97,7 @@ enum OCSPResponse: DERImplicitlyTaggable, Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPResponseStatus {
     init(_ response: OCSPResponse) {
         switch response {

--- a/Sources/X509/OCSP/OCSPResponseBytes.swift
+++ b/Sources/X509/OCSP/OCSPResponseBytes.swift
@@ -57,6 +57,7 @@ struct OCSPResponseBytes: DERImplicitlyTaggable, Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension BasicOCSPResponse {
     init(decoding original: OCSPResponseBytes) throws {
         guard original.responseType == .OCSP.basicResponse else {
@@ -67,6 +68,7 @@ extension BasicOCSPResponse {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OCSPResponseBytes {
     init(encoding original: BasicOCSPResponse) throws {
         self.responseType = .OCSP.basicResponse

--- a/Sources/X509/OCSP/OCSPResponseData.swift
+++ b/Sources/X509/OCSP/OCSPResponseData.swift
@@ -27,6 +27,7 @@ import SwiftASN1
 /// Version         ::=             INTEGER  {  v1(0) }
 /// ```
 ///
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPResponseData: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPSignature.swift
+++ b/Sources/X509/OCSP/OCSPSignature.swift
@@ -21,6 +21,7 @@ import SwiftASN1
 ///    signature               BIT STRING,
 ///    certs               [0] EXPLICIT SEQUENCE OF Certificate OPTIONAL }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPSignature: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPSingleRequest.swift
+++ b/Sources/X509/OCSP/OCSPSingleRequest.swift
@@ -21,6 +21,7 @@ import SwiftASN1
 ///    singleRequestExtensions [0] EXPLICIT Extensions OPTIONAL }
 /// ```
 /// - note: originally named just `Request` in RFC 6960 but prefix `Single` added to avoid naming conflicts with ``OCSPRequest``
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPSingleRequest: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPSingleResponse.swift
+++ b/Sources/X509/OCSP/OCSPSingleResponse.swift
@@ -25,6 +25,7 @@ import SwiftASN1
 ///    singleExtensions   [1]       EXPLICIT Extensions OPTIONAL }
 /// ```
 ///
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPSingleResponse: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/OCSP/OCSPTBSRequest.swift
+++ b/Sources/X509/OCSP/OCSPTBSRequest.swift
@@ -24,6 +24,7 @@ import SwiftASN1
 ///
 /// Version ::= INTEGER { v1(0) }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct OCSPTBSRequest: DERImplicitlyTaggable, Hashable {
     static var defaultIdentifier: ASN1Identifier {
         .sequence

--- a/Sources/X509/PromiseAndFuture.swift
+++ b/Sources/X509/PromiseAndFuture.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 // MARK: - Promise
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 final class Promise<Value: Sendable, Failure: Error> {
     private enum State {
         case unfulfilled(observers: [CheckedContinuation<Result<Value, Failure>, Never>])
@@ -70,8 +71,10 @@ final class Promise<Value: Sendable, Failure: Error> {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Promise: Sendable where Value: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Promise {
     func succeed(with value: Value) {
         self.fulfil(with: .success(value))
@@ -84,6 +87,7 @@ extension Promise {
 
 // MARK: - Future
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct Future<Value: Sendable, Failure: Error> {
     private let promise: Promise<Value, Failure>
 
@@ -98,8 +102,10 @@ struct Future<Value: Sendable, Failure: Error> {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Future: Sendable where Value: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Future {
     var value: Value {
         get async throws {
@@ -108,6 +114,7 @@ extension Future {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Future where Failure == Never {
     var value: Value {
         get async {
@@ -116,6 +123,7 @@ extension Future where Failure == Never {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Result where Failure == Never {
     func get() -> Success {
         switch self {

--- a/Sources/X509/SecKeyWrapper.swift
+++ b/Sources/X509/SecKeyWrapper.swift
@@ -23,6 +23,7 @@ import Foundation
 @preconcurrency import _CryptoExtras
 @preconcurrency import Security
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.PrivateKey {
     /// A wrapper around ``Security.SecKey`` to allow the use of `SecKey` with certificates.
     @usableFromInline

--- a/Sources/X509/Signature.swift
+++ b/Sources/X509/Signature.swift
@@ -21,6 +21,7 @@ import FoundationEssentials
 import Foundation
 #endif
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// An abstract representation of the cryptographic signature on a certificate.
     ///
@@ -68,10 +69,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Signature: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Signature: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Signature: CustomStringConvertible {
     public var description: String {
         switch backing {
@@ -85,6 +89,7 @@ extension Certificate.Signature: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Signature {
     @usableFromInline
     enum BackingSignature: Hashable, Sendable {
@@ -123,6 +128,7 @@ extension Certificate.Signature {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1BitString {
     @inlinable
     init(_ signature: Certificate.Signature) {
@@ -139,6 +145,7 @@ extension ASN1BitString {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1OctetString {
     @inlinable
     init(_ signature: Certificate.Signature) {
@@ -157,6 +164,7 @@ extension ASN1OctetString {
 
 // MARK: Public key operations
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P256.Signing.PublicKey {
     @inlinable
     internal func isValidSignature<Bytes: DataProtocol>(
@@ -184,6 +192,7 @@ extension P256.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P384.Signing.PublicKey {
     @inlinable
     internal func isValidSignature<Bytes: DataProtocol>(
@@ -211,6 +220,7 @@ extension P384.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P521.Signing.PublicKey {
     @inlinable
     internal func isValidSignature<Bytes: DataProtocol>(
@@ -238,6 +248,7 @@ extension P521.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension _RSA.Signing.PublicKey {
     @inlinable
     internal func isValidSignature<Bytes: DataProtocol>(
@@ -267,6 +278,7 @@ extension _RSA.Signing.PublicKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Curve25519.Signing.PublicKey {
     @inlinable
     internal func isValidSignature<Bytes: DataProtocol>(
@@ -290,6 +302,7 @@ extension Curve25519.Signing.PublicKey {
 
 // MARK: Private key operations
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P256.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(
@@ -316,6 +329,7 @@ extension P256.Signing.PrivateKey {
 }
 
 #if canImport(Darwin)
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecureEnclave.P256.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(
@@ -342,6 +356,7 @@ extension SecureEnclave.P256.Signing.PrivateKey {
 }
 #endif
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P384.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(
@@ -367,6 +382,7 @@ extension P384.Signing.PrivateKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P521.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(
@@ -392,6 +408,7 @@ extension P521.Signing.PrivateKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension _RSA.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(
@@ -421,6 +438,7 @@ extension _RSA.Signing.PrivateKey {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Curve25519.Signing.PrivateKey {
     @inlinable
     func signature<Bytes: DataProtocol>(

--- a/Sources/X509/SignatureAlgorithm.swift
+++ b/Sources/X509/SignatureAlgorithm.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// A representation of a kind of signature algorithm.
     ///
@@ -91,10 +92,13 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SignatureAlgorithm: Hashable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SignatureAlgorithm: Sendable {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.SignatureAlgorithm: CustomStringConvertible {
     public var description: String {
         switch self {
@@ -121,6 +125,7 @@ extension Certificate.SignatureAlgorithm: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension AlgorithmIdentifier {
     @inlinable
     init(_ signatureAlgorithm: Certificate.SignatureAlgorithm) {

--- a/Sources/X509/Verifier/AllOfPolicies.swift
+++ b/Sources/X509/Verifier/AllOfPolicies.swift
@@ -32,6 +32,7 @@ import SwiftASN1
 ///     }
 /// }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct AllOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     @usableFromInline
     var policy: Policy

--- a/Sources/X509/Verifier/AnyPolicy.swift
+++ b/Sources/X509/Verifier/AnyPolicy.swift
@@ -25,6 +25,7 @@ import SwiftASN1
 ///     }
 /// }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct AnyPolicy: VerifierPolicy {
     @usableFromInline
     var policy: any VerifierPolicy
@@ -55,6 +56,7 @@ public struct AnyPolicy: VerifierPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct LegacyPolicySet: VerifierPolicy {
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier]
 

--- a/Sources/X509/Verifier/CertificateStore.swift
+++ b/Sources/X509/Verifier/CertificateStore.swift
@@ -15,6 +15,7 @@
 import _CertificateInternals
 
 /// A collection of ``Certificate`` objects for use in a verifier.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct CertificateStore: Sendable, Hashable {
 
     @usableFromInline
@@ -69,6 +70,7 @@ public struct CertificateStore: Sendable, Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateStore {
     @usableFromInline
     struct Resolved {
@@ -96,6 +98,7 @@ extension CertificateStore {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateStore.Resolved {
     @inlinable
     subscript(subject: DistinguishedName) -> [Certificate]? {

--- a/Sources/X509/Verifier/OneOfPolicies.swift
+++ b/Sources/X509/Verifier/OneOfPolicies.swift
@@ -29,6 +29,7 @@ import SwiftASN1
 @resultBuilder
 public struct OneOfPolicyBuilder {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OneOfPolicyBuilder {
     @inlinable
     public static func buildLimitedAvailability<Policy: VerifierPolicy>(_ component: Policy) -> Policy {
@@ -37,6 +38,7 @@ extension OneOfPolicyBuilder {
 }
 
 // MARK: empty policy
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OneOfPolicyBuilder {
     @usableFromInline
     struct Empty: VerifierPolicy {
@@ -59,6 +61,7 @@ extension OneOfPolicyBuilder {
 }
 
 // MARK: concatenated policies
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OneOfPolicyBuilder {
     @usableFromInline
     struct Tuple2<First: VerifierPolicy, Second: VerifierPolicy>: VerifierPolicy {
@@ -114,6 +117,7 @@ extension OneOfPolicyBuilder {
 }
 
 // MARK: if
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OneOfPolicyBuilder {
     @usableFromInline
     struct WrappedOptional<Wrapped>: VerifierPolicy where Wrapped: VerifierPolicy {
@@ -144,6 +148,7 @@ extension OneOfPolicyBuilder {
 }
 
 // MARK: if/else and switch
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OneOfPolicyBuilder {
     @inlinable
     public static func buildEither<First: VerifierPolicy, Second: VerifierPolicy>(
@@ -172,6 +177,7 @@ extension OneOfPolicyBuilder {
 ///     }
 /// }
 /// ```
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct OneOfPolicies<Policy: VerifierPolicy>: VerifierPolicy {
     @usableFromInline
     var policy: Policy

--- a/Sources/X509/Verifier/PolicyBuilder.swift
+++ b/Sources/X509/Verifier/PolicyBuilder.swift
@@ -28,6 +28,7 @@ import SwiftASN1
 @resultBuilder
 public struct PolicyBuilder {}
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     @inlinable
     public static func buildLimitedAvailability<Policy: VerifierPolicy>(_ component: Policy) -> Policy {
@@ -36,6 +37,7 @@ extension PolicyBuilder {
 }
 
 // MARK: empty policy
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     @usableFromInline
     struct Empty: VerifierPolicy {
@@ -58,6 +60,7 @@ extension PolicyBuilder {
 }
 
 // MARK: concatenated policies
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     @usableFromInline
     struct Tuple2<First: VerifierPolicy, Second: VerifierPolicy>: VerifierPolicy {
@@ -106,6 +109,7 @@ extension PolicyBuilder {
 }
 
 // MARK: if
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     @usableFromInline
     struct WrappedOptional<Wrapped>: VerifierPolicy where Wrapped: VerifierPolicy {
@@ -135,6 +139,7 @@ extension PolicyBuilder {
 }
 
 // MARK: if/else and switch
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     /// implementation detail of ``PolicyBuilder`` which should not be used outside the implementation of ``PolicyBuilder``.
     public struct _Either<First: VerifierPolicy, Second: VerifierPolicy>: VerifierPolicy {
@@ -190,6 +195,7 @@ extension PolicyBuilder {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension PolicyBuilder {
     @usableFromInline
     struct CachedVerifyingCriticalExtensions<Wrapped: VerifierPolicy>: VerifierPolicy {

--- a/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/BasicConstraintsPolicy.swift
@@ -20,6 +20,7 @@ import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices the basicConstraints extension.
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct BasicConstraintsPolicy: VerifierPolicy {
     @usableFromInline
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [

--- a/Sources/X509/Verifier/RFC5280/DNSNames.swift
+++ b/Sources/X509/Verifier/RFC5280/DNSNames.swift
@@ -42,6 +42,7 @@ let ASCII_NINE = UInt8(ascii: "9")
 @usableFromInline
 let ASCII_UNDERSCORE = UInt8(ascii: "_")
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NameConstraintsPolicy {
     /// Validates that a dnsName matches a name constraint.
     ///

--- a/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
+++ b/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NameConstraintsPolicy {
     /// Validates that a directory name matches a name constraint.
     ///

--- a/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
@@ -21,6 +21,7 @@ import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices expiry.
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct ExpiryPolicy: VerifierPolicy {
     @usableFromInline
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []

--- a/Sources/X509/Verifier/RFC5280/IPConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/IPConstraints.swift
@@ -14,6 +14,7 @@
 
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NameConstraintsPolicy {
     /// Validates that an IP address matches a constraint.
     ///

--- a/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
@@ -20,6 +20,7 @@ import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices the nameConstraints extension.
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct NameConstraintsPolicy: VerifierPolicy {
     @usableFromInline
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
@@ -226,6 +227,7 @@ struct NameConstraintsPolicy: VerifierPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     @inlinable
     var names: NameSequence {

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -27,6 +27,7 @@ import SwiftASN1
 /// 2. Expiry. Expired certificates are rejected.
 /// 3. Basic Constraints. Police the constraints contained in the ``BasicConstraints`` extension.
 /// 4. Name Constraints. Police the constraints contained in the ``NameConstraints`` extension.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct RFC5280Policy: VerifierPolicy {
     public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
         .X509ExtensionID.basicConstraints,

--- a/Sources/X509/Verifier/RFC5280/URIConstraints.swift
+++ b/Sources/X509/Verifier/RFC5280/URIConstraints.swift
@@ -32,6 +32,7 @@ import Android
 import CoreFoundation
 #endif
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension NameConstraintsPolicy {
     /// Validates that a URI name matches a name constraint.
     ///

--- a/Sources/X509/Verifier/RFC5280/VersionPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/VersionPolicy.swift
@@ -16,6 +16,7 @@ import SwiftASN1
 
 /// A sub-policy of the ``RFC5280Policy`` that polices that version 1 certificates do not contain extensions.
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct VersionPolicy: VerifierPolicy {
     @inlinable
     var verifyingCriticalExtensions: [SwiftASN1.ASN1ObjectIdentifier] { [] }

--- a/Sources/X509/Verifier/ServerIdentityPolicy.swift
+++ b/Sources/X509/Verifier/ServerIdentityPolicy.swift
@@ -58,6 +58,7 @@ public struct ServerIdentityPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ServerIdentityPolicy: VerifierPolicy {
     @inlinable
     public var verifyingCriticalExtensions: [ASN1ObjectIdentifier] {
@@ -249,6 +250,7 @@ extension ServerIdentityPolicy.IPAddress {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     /// Validates that a given leaf certificate is valid for a service.
     ///

--- a/Sources/X509/Verifier/TrustRootLoading.swift
+++ b/Sources/X509/Verifier/TrustRootLoading.swift
@@ -28,6 +28,7 @@ private let rootCAFileSearchPaths = [
     "/etc/pki/tls/certs/ca-bundle.crt",  // Fedora
 ]
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateStore {
     /// A ``CertificateStore`` that includes all root Certificate Authorities (CAs) that
     /// are installed in the systems trust store.
@@ -54,6 +55,7 @@ extension CertificateStore {
         }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CertificateStore {
     @_spi(Testing)
     public static func loadTrustRoots(at searchPaths: [String]) throws -> [DistinguishedName: [Certificate]] {
@@ -92,6 +94,7 @@ extension CertificateStore {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension DispatchQueue {
     func asyncFuture<Success: Sendable>(
         withResultOf work: @Sendable @escaping () throws -> Success

--- a/Sources/X509/Verifier/UnverifiedChain.swift
+++ b/Sources/X509/Verifier/UnverifiedChain.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct UnverifiedCertificateChain: Sendable, Hashable {
     @usableFromInline
     var certificates: [Certificate]
@@ -27,6 +28,7 @@ public struct UnverifiedCertificateChain: Sendable, Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension UnverifiedCertificateChain: RandomAccessCollection {
     @inlinable
     public var startIndex: Int {

--- a/Sources/X509/Verifier/VerificationDiagnostic.swift
+++ b/Sources/X509/Verifier/VerificationDiagnostic.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct VerificationDiagnostic: Sendable {
     struct LeafCertificateHasUnhandledCriticalExtensions: Hashable, Sendable {
         var leafCertificate: Certificate
@@ -98,6 +99,7 @@ public struct VerificationDiagnostic: Sendable {
     var storage: Storage
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic {
     static func leafCertificateHasUnhandledCriticalExtension(
         _ leafCertificate: Certificate,
@@ -223,6 +225,7 @@ extension VerificationDiagnostic {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.Storage {
     static func leafCertificateHasUnhandledCriticalExtension(
         _ leafCertificate: Certificate,
@@ -342,6 +345,7 @@ extension VerificationDiagnostic.Storage {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions {
     @inlinable
     func unhandledCriticalExtensions(
@@ -355,6 +359,7 @@ extension Certificate.Extensions {
 
 // MARK: CustomStringConvertible
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic: CustomStringConvertible {
     /// Produces a human readable description of this ``VerificationDiagnostic`` that is potentially expensive to compute.
     public var description: String {
@@ -362,6 +367,7 @@ extension VerificationDiagnostic: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.Storage: CustomStringConvertible {
     var description: String {
         switch self {
@@ -382,6 +388,7 @@ extension VerificationDiagnostic.Storage: CustomStringConvertible {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LeafCertificateHasUnhandledCriticalExtensions: CustomStringConvertible {
     var description: String {
         """
@@ -396,6 +403,7 @@ extension VerificationDiagnostic.LeafCertificateHasUnhandledCriticalExtensions: 
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LeafCertificateIsInTheRootStoreButDoesNotMeetPolicy: CustomStringConvertible {
     var description: String {
         """
@@ -408,6 +416,7 @@ extension VerificationDiagnostic.LeafCertificateIsInTheRootStoreButDoesNotMeetPo
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.ChainFailsToMeetPolicy: CustomStringConvertible {
     var description: String {
         """
@@ -420,6 +429,7 @@ extension VerificationDiagnostic.ChainFailsToMeetPolicy: CustomStringConvertible
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerHasUnhandledCriticalExtension: CustomStringConvertible {
     var description: String {
         """
@@ -435,6 +445,7 @@ extension VerificationDiagnostic.IssuerHasUnhandledCriticalExtension: CustomStri
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerHasNotSignedCertificate: CustomStringConvertible {
     var description: String {
         """
@@ -446,6 +457,7 @@ extension VerificationDiagnostic.IssuerHasNotSignedCertificate: CustomStringConv
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.SearchingForIssuerOfPartialChain: CustomStringConvertible {
     var description: String {
         """
@@ -456,6 +468,7 @@ extension VerificationDiagnostic.SearchingForIssuerOfPartialChain: CustomStringC
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInRootStore: CustomStringConvertible {
     var description: String {
         """
@@ -468,6 +481,7 @@ extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInRootStore:
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInIntermediateStore: CustomStringConvertible {
     var description: String {
         """
@@ -480,6 +494,7 @@ extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInIntermedia
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundValidCertificateChain: CustomStringConvertible {
     var description: String {
         """
@@ -490,6 +505,7 @@ extension VerificationDiagnostic.FoundValidCertificateChain: CustomStringConvert
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.CouldNotValidateLeafCertificate: CustomStringConvertible {
     var description: String {
         """
@@ -499,6 +515,7 @@ extension VerificationDiagnostic.CouldNotValidateLeafCertificate: CustomStringCo
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerIsAlreadyInTheChain: CustomStringConvertible {
     var description: String {
         """
@@ -511,6 +528,7 @@ extension VerificationDiagnostic.IssuerIsAlreadyInTheChain: CustomStringConverti
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LoadingTrustRootsFailed: CustomStringConvertible {
     var description: String {
         """
@@ -521,6 +539,7 @@ extension VerificationDiagnostic.LoadingTrustRootsFailed: CustomStringConvertibl
 
 // MARK: CustomDebugStringConvertible
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic: CustomDebugStringConvertible {
     public var debugDescription: String {
         // this just adds quotes around the string and escapes any characters not suitable for displaying in a structural display.
@@ -530,6 +549,7 @@ extension VerificationDiagnostic: CustomDebugStringConvertible {
 
 // MARK: Multiline Description
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic {
     /// Produces a human readable description of this ``VerificationDiagnostic`` over multiple lines for better readability
     /// but includes otherwise the same information as ``description``.
@@ -538,6 +558,7 @@ extension VerificationDiagnostic {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.Storage {
     var multilineDescription: String {
         switch self {
@@ -559,6 +580,7 @@ extension VerificationDiagnostic.Storage {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LeafCertificateHasUnhandledCriticalExtensions {
     var multilineDescription: String {
         """
@@ -575,6 +597,7 @@ extension VerificationDiagnostic.LeafCertificateHasUnhandledCriticalExtensions {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LeafCertificateIsInTheRootStoreButDoesNotMeetPolicy {
     var multilineDescription: String {
         """
@@ -589,6 +612,7 @@ extension VerificationDiagnostic.LeafCertificateIsInTheRootStoreButDoesNotMeetPo
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.ChainFailsToMeetPolicy {
     var multilineDescription: String {
         """
@@ -603,6 +627,7 @@ extension VerificationDiagnostic.ChainFailsToMeetPolicy {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerHasUnhandledCriticalExtension {
     var multilineDescription: String {
         """
@@ -620,6 +645,7 @@ extension VerificationDiagnostic.IssuerHasUnhandledCriticalExtension {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerHasNotSignedCertificate {
     var multilineDescription: String {
         """
@@ -632,6 +658,7 @@ extension VerificationDiagnostic.IssuerHasNotSignedCertificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.SearchingForIssuerOfPartialChain {
     var multilineDescription: String {
         """
@@ -642,6 +669,7 @@ extension VerificationDiagnostic.SearchingForIssuerOfPartialChain {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInRootStore {
     var multilineDescription: String {
         """
@@ -654,6 +682,7 @@ extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInRootStore 
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInIntermediateStore {
     var multilineDescription: String {
         """
@@ -666,6 +695,7 @@ extension VerificationDiagnostic.FoundCandidateIssuersOfPartialChainInIntermedia
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.FoundValidCertificateChain {
     var multilineDescription: String {
         """
@@ -676,6 +706,7 @@ extension VerificationDiagnostic.FoundValidCertificateChain {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.CouldNotValidateLeafCertificate {
     var multilineDescription: String {
         """
@@ -685,6 +716,7 @@ extension VerificationDiagnostic.CouldNotValidateLeafCertificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.IssuerIsAlreadyInTheChain {
     var multilineDescription: String {
         """
@@ -697,6 +729,7 @@ extension VerificationDiagnostic.IssuerIsAlreadyInTheChain {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationDiagnostic.LoadingTrustRootsFailed {
     var multilineDescription: String {
         """

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import SwiftASN1
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public struct Verifier<Policy: VerifierPolicy> {
     public var rootCertificates: CertificateStore
 
@@ -24,6 +25,7 @@ public struct Verifier<Policy: VerifierPolicy> {
         self.policy = try policy()
     }
 
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     public mutating func validate(
         leafCertificate: Certificate,
         intermediates: CertificateStore,
@@ -145,6 +147,7 @@ public struct Verifier<Policy: VerifierPolicy> {
         return .couldNotValidate(policyFailures)
     }
 
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     private func shouldSkipAddingCertificate(
         partialChain: CandidatePartialChain,
         nextCertificate: Certificate,
@@ -181,11 +184,13 @@ public struct Verifier<Policy: VerifierPolicy> {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public enum VerificationResult: Hashable, Sendable {
     case validCertificate([Certificate])
     case couldNotValidate([PolicyFailure])
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension VerificationResult {
     public struct PolicyFailure: Hashable, Sendable {
         public var chain: UnverifiedCertificateChain
@@ -199,6 +204,7 @@ extension VerificationResult {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct CandidatePartialChain: Hashable {
     var chain: [Certificate]
 
@@ -210,6 +216,7 @@ struct CandidatePartialChain: Hashable {
     }
 
     /// Whether this partial chain already contains this certificate.
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     func contains(certificate: Certificate) -> Bool {
         // We don't do direct equality, as RFC 4158 § 2.4.1 notes that even certs that aren't
         // bytewise equal can cause arbitrarily long trust paths and weird loops. In particular, we're
@@ -240,6 +247,7 @@ struct CandidatePartialChain: Hashable {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Array where Element == Certificate {
     fileprivate mutating func sortBySuitabilityForIssuing(certificate: Certificate) {
         // First, an early exit. If the subject doesn't have an AKI extension, we don't need
@@ -252,6 +260,7 @@ extension Array where Element == Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate {
     func issuerPreference(subjectAKI: AuthorityKeyIdentifier) -> Int {
         guard let ski = try? self.extensions.subjectKeyIdentifier else {
@@ -274,6 +283,7 @@ extension Certificate {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension UnverifiedCertificateChain {
     fileprivate init(chain: CandidatePartialChain, root: Certificate) {
         var certificates = chain.chain
@@ -283,6 +293,7 @@ extension UnverifiedCertificateChain {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Certificate.Extensions {
     fileprivate var subjectAlternativeNameBytes: ArraySlice<UInt8>? {
         return self[oid: .X509ExtensionID.subjectAlternativeName].map { $0.value }

--- a/Sources/X509/Verifier/VerifierPolicy.swift
+++ b/Sources/X509/Verifier/VerifierPolicy.swift
@@ -28,6 +28,7 @@ import SwiftASN1
 /// the basic checks from that RFC. Other objects are less common, such as ``OCSPVerifierPolicy``, which performs live
 /// revocation checking. Users can also implement their own policies to enable swift-certificates to support other
 /// use-cases.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 public protocol VerifierPolicy {
     /// The X.509 extension types that this policy understands and enforces.
     ///

--- a/Sources/X509/X509BaseTypes/ECDSASignature.swift
+++ b/Sources/X509/X509BaseTypes/ECDSASignature.swift
@@ -76,21 +76,25 @@ struct ECDSASignature: DERImplicitlyTaggable, Hashable, Sendable {
     }
 
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     init(_ sig: P256.Signing.ECDSASignature) {
         self = .init(rawSignatureBytes: sig.rawRepresentation)
     }
 
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     init(_ sig: P384.Signing.ECDSASignature) {
         self = .init(rawSignatureBytes: sig.rawRepresentation)
     }
 
     @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
     init(_ sig: P521.Signing.ECDSASignature) {
         self = .init(rawSignatureBytes: sig.rawRepresentation)
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P256.Signing.ECDSASignature {
     @inlinable
     init?(_ signature: ECDSASignature) {
@@ -118,6 +122,7 @@ extension P256.Signing.ECDSASignature {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P384.Signing.ECDSASignature {
     @inlinable
     init?(_ signature: ECDSASignature) {
@@ -145,6 +150,7 @@ extension P384.Signing.ECDSASignature {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P521.Signing.ECDSASignature {
     @inlinable
     init?(_ signature: ECDSASignature) {

--- a/Sources/X509/X509BaseTypes/TBSCertificate.swift
+++ b/Sources/X509/X509BaseTypes/TBSCertificate.swift
@@ -40,6 +40,7 @@ import SwiftASN1
 typealias UniqueIdentifier = ASN1BitString
 
 @usableFromInline
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 struct TBSCertificate: DERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
     static var defaultIdentifier: ASN1Identifier {


### PR DESCRIPTION
Minimum deployment versions in package manifests can be problematic for libraries, because changing them or adding them to an existing package that doesn't already use them forces SemVer breaking majors.

Furthermore, depending on a new library that specifies minimum deployment targets would force the adopting library to also have to add these platforms to its manifest (which would in turn force a major).

This PR removes the platforms stanza from the package manifest and replaces it with availability guards where necessary.
`swift-certificates` needed the platforms stanza because `swift-crypto` forced it onto its adopters. After https://github.com/apple/swift-crypto/pull/331, this isn't needed anymore.