### PR TITLE
Enable macOS CI on merge to main and daily timer

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,5 +29,10 @@ jobs:
 
   static-sdk:
     name: Static SDK
-    # Workaround https://github.com/nektos/act/issues/1875
     uses: apple/swift-nio/.github/workflows/static_sdk.yml@main
+
+  macos-tests:
+    name: macOS tests
+    uses: apple/swift-nio/.github/workflows/macos_tests.yml@main
+    with:
+      build_scheme: swift-certificates


### PR DESCRIPTION
Enable macOS CI on merge to main and daily timer

### Motivation:

* Improve test coverage
* Check test pass/fail status
* Monitor CI throughput

### Modifications:

Enable macOS CI to be run on all merges to main and on a daily timer.

### Result:

Improved test coverage run out-of-band at the moment so we can get a feeling for if any changes need to be made in the repo or in the CI pipelines to ensure timely and stable checks.