### PR TITLE
Remove warnings as errors from 5.9 CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,7 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error"
+      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"


### PR DESCRIPTION
Warnings as errors is enabled on 5.9, but this is preventing us from adding visionOS as a platform in our availability guards. Since we're not regressing anything by doing this, and we're close to dropping support for 5.9 anyways, we should remove this setting so that we can support visionOS.