### PR TITLE
Add new `Certificate.PrivateKey` init from PKCS8 DER bytes

### DIFF
--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -303,24 +303,7 @@ extension Certificate.PrivateKey {
             self = try .init(ecdsaAlgorithm: sec1.algorithm, rawEncodedPrivateKey: sec1.privateKey.bytes)
 
         case Self.pemDiscriminatorForPKCS8:
-            let pkcs8 = try PKCS8PrivateKey(derEncoded: pemDocument.derBytes)
-            switch pkcs8.algorithm {
-            case .ecdsaP256, .ecdsaP384, .ecdsaP521:
-                let sec1 = try SEC1PrivateKey(derEncoded: pkcs8.privateKey.bytes)
-                if let innerAlgorithm = sec1.algorithm, innerAlgorithm != pkcs8.algorithm {
-                    throw ASN1Error.invalidASN1Object(
-                        reason: "algorithm mismatch. PKCS#8 is \(pkcs8.algorithm) but inner SEC1 is \(innerAlgorithm)"
-                    )
-                }
-                self = try .init(ecdsaAlgorithm: pkcs8.algorithm, rawEncodedPrivateKey: sec1.privateKey.bytes)
-
-            case .rsaKey:
-                self = try .init(_CryptoExtras._RSA.Signing.PrivateKey(derRepresentation: pkcs8.privateKey.bytes))
-            case .ed25519:
-                self = try .init(Curve25519.Signing.PrivateKey(pkcs8Key: pkcs8))
-            default:
-                throw CertificateError.unsupportedPrivateKey(reason: "unknown algorithm \(pkcs8.algorithm)")
-            }
+            self = try .init(pkcs8DERBytes: pemDocument.derBytes)
 
         default:
             throw ASN1Error.invalidPEMDocument(
@@ -361,6 +344,31 @@ extension Certificate.PrivateKey {
         case .secKey(let key): return try key.pemDocument()
         #endif
         case .ed25519(let key): return key.pemRepresentation
+        }
+    }
+}
+
+@available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, macCatalyst 14, visionOS 1.0, *)
+extension Certificate.PrivateKey {
+    /// Initialize a new certificate private key from PKCS8-format DER bytes.
+    public init(pkcs8DERBytes: [UInt8]) throws {
+        let pkcs8 = try PKCS8PrivateKey(derEncoded: pkcs8DERBytes)
+        switch pkcs8.algorithm {
+        case .ecdsaP256, .ecdsaP384, .ecdsaP521:
+            let sec1 = try SEC1PrivateKey(derEncoded: pkcs8.privateKey.bytes)
+            if let innerAlgorithm = sec1.algorithm, innerAlgorithm != pkcs8.algorithm {
+                throw ASN1Error.invalidASN1Object(
+                    reason: "algorithm mismatch. PKCS#8 is \(pkcs8.algorithm) but inner SEC1 is \(innerAlgorithm)"
+                )
+            }
+            self = try .init(ecdsaAlgorithm: pkcs8.algorithm, rawEncodedPrivateKey: sec1.privateKey.bytes)
+
+        case .rsaKey:
+            self = try .init(_CryptoExtras._RSA.Signing.PrivateKey(derRepresentation: pkcs8.privateKey.bytes))
+        case .ed25519:
+            self = try .init(Curve25519.Signing.PrivateKey(pkcs8Key: pkcs8))
+        default:
+            throw CertificateError.unsupportedPrivateKey(reason: "unknown algorithm \(pkcs8.algorithm)")
         }
     }
 }

--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -303,7 +303,7 @@ extension Certificate.PrivateKey {
             self = try .init(ecdsaAlgorithm: sec1.algorithm, rawEncodedPrivateKey: sec1.privateKey.bytes)
 
         case Self.pemDiscriminatorForPKCS8:
-            self = try .init(pkcs8DERBytes: pemDocument.derBytes)
+            self = try .init(derBytes: pemDocument.derBytes)
 
         default:
             throw ASN1Error.invalidPEMDocument(
@@ -351,8 +351,8 @@ extension Certificate.PrivateKey {
 @available(macOS 11.0, iOS 14, tvOS 14, watchOS 7, macCatalyst 14, visionOS 1.0, *)
 extension Certificate.PrivateKey {
     /// Initialize a new certificate private key from PKCS8-format DER bytes.
-    public init(pkcs8DERBytes: [UInt8]) throws {
-        let pkcs8 = try PKCS8PrivateKey(derEncoded: pkcs8DERBytes)
+    public init(derBytes: [UInt8]) throws {
+        let pkcs8 = try PKCS8PrivateKey(derEncoded: derBytes)
         switch pkcs8.algorithm {
         case .ecdsaP256, .ecdsaP384, .ecdsaP521:
             let sec1 = try SEC1PrivateKey(derEncoded: pkcs8.privateKey.bytes)

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -761,3 +761,50 @@ final class CertificateDERTests: XCTestCase {
         XCTAssertNoThrow(try decoded.extensions.nameConstraints)
     }
 }
+
+final class CertificatePrivateKeyDEREncodedTests: XCTestCase {
+    func testECDSAP256() throws {
+        let key = P256.Signing.PrivateKey()
+        let derBytes = Array(key.derRepresentation)
+        let parsedKey = try Certificate.PrivateKey(derBytes: derBytes)
+
+        XCTAssertEqual(parsedKey.backing, .p256(key))
+    }
+
+    func testECDSAP384() throws {
+        let key = P384.Signing.PrivateKey()
+        let derBytes = Array(key.derRepresentation)
+        let parsedKey = try Certificate.PrivateKey(derBytes: derBytes)
+
+        XCTAssertEqual(parsedKey.backing, .p384(key))
+    }
+
+    func testECDSAP521() throws {
+        let key = P521.Signing.PrivateKey()
+        let derBytes = Array(key.derRepresentation)
+        let parsedKey = try Certificate.PrivateKey(derBytes: derBytes)
+
+        XCTAssertEqual(parsedKey.backing, .p521(key))
+    }
+
+    func testED25519() throws {
+        let key = Curve25519.Signing.PrivateKey()
+        let derBytes = key.derRepresentation
+        let parsedKey = try Certificate.PrivateKey(derBytes: derBytes)
+
+        XCTAssertEqual(parsedKey.backing, .ed25519(key))
+    }
+
+    func testRSA() throws {
+        // Unlike other algorithms, RSA's bytes representation is not in PKCS#8 format, so we have
+        // to bridge it by first serialising the key as a PKCS#8 PEM document, and then getting
+        // its DER bytes.
+        let key = try _CryptoExtras._RSA.Signing.PrivateKey(keySize: .bits2048)
+        let pkcs8 = key.pkcs8PEMRepresentation
+        let pemDoc = try PEMDocument(pemString: pkcs8)
+        let derBytes = pemDoc.derBytes
+        let parsedKey = try Certificate.PrivateKey(derBytes: derBytes)
+
+        XCTAssertEqual(parsedKey.backing, .rsa(key))
+    }
+}


### PR DESCRIPTION
This PR adds a new `init(derBytes:)` to initialise a private key in PKCS8 format from an array of DER bytes.