### PR TITLE
Drop Swift 5.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,7 +15,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.8
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 4835000
-}

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 5794000
-}

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 5802000
-}

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.TinyArray.append.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.TinyArray.append.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 10000
-}

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 0
-}

--- a/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Verifier.p90.json
+++ b/Benchmarks/Thresholds/5.9/CertificatesBenchmark.Verifier.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 1065000
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version:5.10
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project

--- a/Sources/X509/CertificateSerialNumber.swift
+++ b/Sources/X509/CertificateSerialNumber.swift
@@ -100,7 +100,6 @@ extension Certificate.SerialNumber: CustomStringConvertible {
     }
 }
 
-#if swift(>=5.8)
 @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, macCatalyst 16.4, visionOS 1.0, *)
 extension Certificate.SerialNumber: ExpressibleByIntegerLiteral {
     /// Constructs a serial number from an integer.
@@ -119,7 +118,6 @@ extension Certificate.SerialNumber: ExpressibleByIntegerLiteral {
         self.bytes = ArraySlice(normalisingToASN1IntegerForm: bytes)
     }
 }
-#endif
 
 extension [UInt8] {
     @inlinable

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
@@ -15,10 +15,8 @@
 import SwiftASN1
 #if canImport(FoundationEssentials)
 import FoundationEssentials
-#elseif canImport(Darwin) || swift(>=5.9.1)
-import Foundation
 #else
-@preconcurrency import Foundation
+import Foundation
 #endif
 
 /// A representation of a CMS signature over some data.

--- a/Sources/X509/OCSP/OCSPPolicy.swift
+++ b/Sources/X509/OCSP/OCSPPolicy.swift
@@ -16,10 +16,8 @@ import SwiftASN1
 import Crypto
 #if canImport(FoundationEssentials)
 import FoundationEssentials
-#elseif canImport(Darwin) || swift(>=5.9.1)
-import Foundation
 #else
-@preconcurrency import Foundation
+import Foundation
 #endif
 
 // Swift CI has implicit concurrency disabled

--- a/Tests/X509Tests/CertificateTests.swift
+++ b/Tests/X509Tests/CertificateTests.swift
@@ -25,7 +25,6 @@ final class CertificateTests: XCTestCase {
         XCTAssertEqual(s, "a:14:1e:28")
     }
 
-    #if swift(>=5.8)
     @available(macOS 13.3, iOS 16.4, watchOS 9.4, tvOS 16.4, macCatalyst 16.4, visionOS 1.0, *)
     func testSerialNumberStaticBigInt() {
         XCTAssertEqual(
@@ -40,7 +39,6 @@ final class CertificateTests: XCTestCase {
         )
         XCTAssertEqual(Certificate.SerialNumber(123_456_789), 123_456_789)
     }
-    #endif
 
     func testSerialNumberInits() {
         XCTAssertEqual(Certificate.SerialNumber(bytes: [0, 1, 2, 3, 4, 5, 6, 7, 8]).bytes, [1, 2, 3, 4, 5, 6, 7, 8])

--- a/Tests/X509Tests/OCSPPolicyVerifierTests.swift
+++ b/Tests/X509Tests/OCSPPolicyVerifierTests.swift
@@ -18,10 +18,8 @@ import SwiftASN1
 @testable import X509
 #if canImport(FoundationEssentials)
 import FoundationEssentials
-#elseif canImport(Darwin) || swift(>=5.9.1)
-import Foundation
 #else
-@preconcurrency import Foundation
+import Foundation
 #endif
 
 actor TestRequester: OCSPRequester {


### PR DESCRIPTION
Motivation:

Swift 5.9 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 5.10
* Remove Swift 5.9 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
