### PR TITLE
Custom certificate store

### DIFF
--- a/Sources/X509/CMakeLists.txt
+++ b/Sources/X509/CMakeLists.txt
@@ -92,6 +92,7 @@ add_library(X509
   "Verifier/AllOfPolicies.swift"
   "Verifier/AnyPolicy.swift"
   "Verifier/CertificateStore.swift"
+  "Verifier/CustomCertificateStore.swift"
   "Verifier/OneOfPolicies.swift"
   "Verifier/PolicyBuilder.swift"
   "Verifier/RFC5280/BasicConstraintsPolicy.swift"

--- a/Sources/X509/Verifier/CertificateStore.swift
+++ b/Sources/X509/Verifier/CertificateStore.swift
@@ -138,16 +138,18 @@ extension CertificateStore {
 extension CertificateStore.Resolved {
     @usableFromInline
     subscript(subject: DistinguishedName) -> [Certificate]? {
-        switch self {
-        case .custom(let inner): inner[subject]
-        case .concrete(let inner): inner[subject]
+        get async {
+            switch self {
+            case .custom(let inner): await inner[subject]
+            case .concrete(let inner): inner[subject]
+            }
         }
     }
 
     @usableFromInline
-    func contains(_ certificate: Certificate) -> Bool {
+    func contains(_ certificate: Certificate) async -> Bool {
         switch self {
-        case .custom(let inner): inner.contains(certificate)
+        case .custom(let inner): await inner.contains(certificate)
         case .concrete(let inner): inner.contains(certificate)
         }
     }

--- a/Sources/X509/Verifier/CertificateStore.swift
+++ b/Sources/X509/Verifier/CertificateStore.swift
@@ -136,7 +136,7 @@ extension CertificateStore {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension CertificateStore.Resolved {
-    @usableFromInline
+    @inlinable
     subscript(subject: DistinguishedName) -> [Certificate]? {
         get async {
             switch self {
@@ -146,7 +146,7 @@ extension CertificateStore.Resolved {
         }
     }
 
-    @usableFromInline
+    @inlinable
     func contains(_ certificate: Certificate) async -> Bool {
         switch self {
         case .custom(let inner): await inner.contains(certificate)

--- a/Sources/X509/Verifier/CertificateStore.swift
+++ b/Sources/X509/Verifier/CertificateStore.swift
@@ -19,24 +19,30 @@ import _CertificateInternals
 public struct CertificateStore: Sendable, Hashable {
 
     @usableFromInline
-    var systemTrustStore: Bool
-    @usableFromInline
-    var additionalTrustRoots: [DistinguishedName: [Certificate]]
+    var backing: Backing
 
     @inlinable
     public init() {
         self.init([])
     }
 
+    /// Wrap a ``CustomCertificateStore`` in a ``CertificateStore`` so the custom
+    /// implementation it can be used interchangeably. For details on why one
+    /// may decide to implement a ``CustomCertificateStore``, please see the
+    /// documentation on that protocol.
+    @inlinable
+    public init(custom: some CustomCertificateStore) {
+        backing = .custom(AnyCustomCertificateStore(custom))
+    }
+
+    /// Initialize a certificate store from a sequence of certificates.
     @inlinable
     public init(_ certificates: some Sequence<Certificate>) {
-        self.systemTrustStore = false
-        self.additionalTrustRoots = Dictionary(grouping: certificates, by: \.subject)
+        backing = .concrete(.init(certificates))
     }
 
     init(systemTrustStore: Bool) {
-        self.systemTrustStore = systemTrustStore
-        self.additionalTrustRoots = [:]
+        backing = .concrete(.init(systemTrustStore: systemTrustStore))
     }
 
     @inlinable
@@ -46,9 +52,7 @@ public struct CertificateStore: Sendable, Hashable {
 
     @inlinable
     public mutating func append(contentsOf certificates: some Sequence<Certificate>) {
-        for certificate in certificates {
-            additionalTrustRoots[certificate.subject, default: []].append(certificate)
-        }
+        backing.append(contentsOf: certificates)
     }
 
     @inlinable
@@ -66,14 +70,93 @@ public struct CertificateStore: Sendable, Hashable {
     }
 
     func resolve(diagnosticsCallback: ((VerificationDiagnostic) -> Void)?) async -> Resolved {
-        await Resolved(self, diagnosticsCallback: diagnosticsCallback)
+        switch self.backing {
+        case .custom(let inner): .custom(inner)
+        case .concrete(let inner): .concrete(await ConcreteResolved(inner, diagnosticsCallback: diagnosticsCallback))
+        }
     }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension CertificateStore {
     @usableFromInline
-    struct Resolved {
+    struct ConcreteBacking: Sendable, Hashable {
+        @usableFromInline
+        var systemTrustStore: Bool
+        @usableFromInline
+        var additionalTrustRoots: [DistinguishedName: [Certificate]]
+
+        @inlinable
+        public init(_ certificates: some Sequence<Certificate>) {
+            self.systemTrustStore = false
+            self.additionalTrustRoots = Dictionary(grouping: certificates, by: \.subject)
+        }
+
+        @inlinable
+        init(systemTrustStore: Bool) {
+            self.systemTrustStore = systemTrustStore
+            self.additionalTrustRoots = [:]
+        }
+
+        @inlinable
+        mutating func append(contentsOf certificates: some Sequence<Certificate>) {
+            for certificate in certificates {
+                self.additionalTrustRoots[certificate.subject, default: []].append(certificate)
+            }
+        }
+    }
+
+    @usableFromInline
+    enum Backing: Sendable, Hashable {
+        case custom(AnyCustomCertificateStore)
+        case concrete(ConcreteBacking)
+
+        @inlinable
+        mutating func append(contentsOf certificates: some Sequence<Certificate>) {
+            switch self {
+            case .custom(var inner):
+                inner.append(contentsOf: certificates)
+                self = .custom(inner)
+            case .concrete(var inner):
+                inner.append(contentsOf: certificates)
+                self = .concrete(inner)
+            }
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension CertificateStore {
+    @usableFromInline
+    enum Resolved {
+        case custom(AnyCustomCertificateStore)
+        case concrete(ConcreteResolved)
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension CertificateStore.Resolved {
+    @usableFromInline
+    subscript(subject: DistinguishedName) -> [Certificate]? {
+        switch self {
+        case .custom(let inner): inner[subject]
+        case .concrete(let inner): inner[subject]
+        }
+    }
+
+    @usableFromInline
+    func contains(_ certificate: Certificate) -> Bool {
+        switch self {
+        case .custom(let inner): inner.contains(certificate)
+        case .concrete(let inner): inner.contains(certificate)
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension CertificateStore {
+    @usableFromInline
+    struct ConcreteResolved {
 
         @usableFromInline
         var systemTrustRoots: [DistinguishedName: [Certificate]]
@@ -81,7 +164,7 @@ extension CertificateStore {
         @usableFromInline
         var additionalTrustRoots: [DistinguishedName: [Certificate]]
 
-        init(_ store: CertificateStore, diagnosticsCallback: ((VerificationDiagnostic) -> Void)?) async {
+        init(_ store: ConcreteBacking, diagnosticsCallback: ((VerificationDiagnostic) -> Void)?) async {
             if store.systemTrustStore {
                 do {
                     systemTrustRoots = try await CertificateStore.cachedSystemTrustRootsFuture.value
@@ -99,7 +182,7 @@ extension CertificateStore {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension CertificateStore.Resolved {
+extension CertificateStore.ConcreteResolved {
     @inlinable
     subscript(subject: DistinguishedName) -> [Certificate]? {
         get {

--- a/Sources/X509/Verifier/CustomCertificateStore.swift
+++ b/Sources/X509/Verifier/CustomCertificateStore.swift
@@ -1,0 +1,116 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// Implement the ``CustomCertificateStore`` if you want to perform dynamic
+/// certificate lookup, or if you need custom logic when matching the
+/// ``DistinguishedName`` of an Issuer with the Subject of the issuer
+/// certificate.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public protocol CustomCertificateStore: Sendable, Hashable {
+    /// Obtain a list of certificates which has a given subject.
+    subscript(subject: DistinguishedName) -> [Certificate]? {
+        get
+    }
+
+    /// Validate if a given certificate is known to exist in this certificate
+    /// store.
+    func contains(_ certificate: Certificate) -> Bool
+
+    /// Add a certificate to this certificate store.
+    mutating func append(contentsOf certificates: some Sequence<Certificate>)
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+@usableFromInline
+struct AnyCustomCertificateStore: CustomCertificateStore {
+    @usableFromInline
+    var value: any DynCustomCertificateStore
+
+    @usableFromInline
+    init<T: CustomCertificateStore>(_ value: T) {
+        self.value = Backing(value)
+    }
+
+    @inlinable
+    subscript(subject: DistinguishedName) -> [Certificate]? {
+        value[subject]
+    }
+
+    @inlinable
+    func contains(_ certificate: Certificate) -> Bool {
+        value.contains(certificate)
+    }
+
+    @inlinable
+    mutating func append(contentsOf certificates: some Sequence<Certificate>) {
+        value.append(contentsOf: certificates)
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension AnyCustomCertificateStore: Hashable {
+    public static func == (lhs: AnyCustomCertificateStore, rhs: AnyCustomCertificateStore) -> Bool {
+        return lhs.value.isEqual(rhs.value, recurse: true)
+    }
+
+    public var hashValue: Int {
+        return value.hashValue
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        value.hash(into: &hasher)
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension AnyCustomCertificateStore {
+    @usableFromInline
+    protocol DynCustomCertificateStore: CustomCertificateStore {
+        func isEqual(_ rhs: any DynCustomCertificateStore, recurse: Bool) -> Bool
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension AnyCustomCertificateStore {
+    struct Backing<T: CustomCertificateStore>: DynCustomCertificateStore {
+        var value: T
+
+        init(_ value: T) {
+            self.value = value
+        }
+
+        subscript(subject: DistinguishedName) -> [Certificate]? {
+            value[subject]
+        }
+
+        func contains(_ certificate: Certificate) -> Bool {
+            value.contains(certificate)
+        }
+
+        @inlinable
+        mutating func append(contentsOf certificates: some Sequence<Certificate>) {
+            value.append(contentsOf: certificates)
+        }
+
+        func isEqual(_ rhs: any DynCustomCertificateStore, recurse: Bool) -> Bool {
+            guard let rhs = rhs as? Self else {
+                guard recurse else {
+                    return false
+                }
+                return rhs.isEqual(self, recurse: false)
+            }
+            return self == rhs
+        }
+    }
+}

--- a/Sources/X509/Verifier/Verifier.swift
+++ b/Sources/X509/Verifier/Verifier.swift
@@ -55,7 +55,7 @@ public struct Verifier<Policy: VerifierPolicy> {
         // which may let us chain through another variant of this certificate and build a valid chain. This is a very
         // deliberate choice: certificates that assert the same combination of (subject, public key, SAN) but different
         // extensions or policies should not be tolerated by this check, and will be ignored.
-        if rootCertificates.contains(leafCertificate) {
+        if await rootCertificates.contains(leafCertificate) {
             let unverifiedChain = UnverifiedCertificateChain([leafCertificate])
 
             switch await self.policy.chainMeetsPolicyRequirements(chain: unverifiedChain) {
@@ -81,7 +81,7 @@ public struct Verifier<Policy: VerifierPolicy> {
             diagnosticCallback?(.searchingForIssuerOfPartialChain(nextPartialCandidate))
             // We want to search for parents. Our preferred parent comes from the root store, as this will potentially
             // produce smaller chains.
-            if var rootParents = rootCertificates[nextPartialCandidate.currentTip.issuer] {
+            if var rootParents = await rootCertificates[nextPartialCandidate.currentTip.issuer] {
                 // We then want to sort by suitability.
                 rootParents.sortBySuitabilityForIssuing(certificate: nextPartialCandidate.currentTip)
                 diagnosticCallback?(
@@ -115,7 +115,7 @@ public struct Verifier<Policy: VerifierPolicy> {
                 }
             }
 
-            if var intermediateParents = intermediates[nextPartialCandidate.currentTip.issuer] {
+            if var intermediateParents = await intermediates[nextPartialCandidate.currentTip.issuer] {
                 // We then want to sort by suitability.
                 intermediateParents.sortBySuitabilityForIssuing(certificate: nextPartialCandidate.currentTip)
                 diagnosticCallback?(

--- a/Tests/X509Tests/CertificateStore.swift
+++ b/Tests/X509Tests/CertificateStore.swift
@@ -82,13 +82,12 @@ final class CertificateStoreTests: XCTestCase {
 
     struct CertStore: CustomCertificateStore {
         subscript(subject: X509.DistinguishedName) -> [X509.Certificate]? {
-            let found = self.trustRoots[normalizeDistinguishedName(subject)]
-            print("trustRoots=\(self.trustRoots)")
-            // print("Looking up [\(subject)] -> \(found)")
-            return found
+            get async {
+                self.trustRoots[normalizeDistinguishedName(subject)]
+            }
         }
 
-        func contains(_ certificate: X509.Certificate) -> Bool {
+        func contains(_ certificate: X509.Certificate) async -> Bool {
             self.trustRoots[normalizeDistinguishedName(certificate.subject)]?.contains(certificate) == true
         }
 

--- a/Tests/X509Tests/CertificateStore.swift
+++ b/Tests/X509Tests/CertificateStore.swift
@@ -15,6 +15,7 @@
 import XCTest
 import SwiftASN1
 @_spi(Testing) @testable import X509
+@preconcurrency import Crypto
 
 final class CertificateStoreTests: XCTestCase {
     #if os(Linux)
@@ -60,11 +61,191 @@ final class CertificateStoreTests: XCTestCase {
         XCTAssertEqual(log, [])
         XCTAssertEqual(store.values.lazy.map(\.count).reduce(0, +), 137)
     }
+
+    static func normalizeDistinguishedName(_ dn: DistinguishedName) -> DistinguishedName {
+        DistinguishedName(
+            dn.map {
+                RelativeDistinguishedName(
+                    $0.map {
+                        guard let str = String($0.value) else {
+                            return $0
+                        }
+                        return RelativeDistinguishedName.Attribute(
+                            type: $0.type,
+                            value: RelativeDistinguishedName.Attribute.Value(utf8String: str)
+                        )
+                    }
+                )
+            }
+        )
+    }
+
+    struct CertStore: CustomCertificateStore {
+        subscript(subject: X509.DistinguishedName) -> [X509.Certificate]? {
+            let found = self.trustRoots[normalizeDistinguishedName(subject)]
+            print("trustRoots=\(self.trustRoots)")
+            // print("Looking up [\(subject)] -> \(found)")
+            return found
+        }
+
+        func contains(_ certificate: X509.Certificate) -> Bool {
+            self.trustRoots[normalizeDistinguishedName(certificate.subject)]?.contains(certificate) == true
+        }
+
+        mutating func append(contentsOf certificates: some Sequence<X509.Certificate>) {
+            for certificate in certificates {
+                self.trustRoots[normalizeDistinguishedName(certificate.subject), default: []].append(certificate)
+            }
+        }
+
+        @usableFromInline
+        var trustRoots: [DistinguishedName: [Certificate]]
+
+        @inlinable
+        public init(_ certificates: some Sequence<Certificate>) {
+            self.trustRoots = Dictionary(grouping: certificates) {
+                normalizeDistinguishedName($0.subject)
+            }
+        }
+    }
+
+    private static let referenceTime = Date()
+
+    private static let ca1PrivateKey = P384.Signing.PrivateKey()
+    private static let ca1: Certificate = {
+        // Force CA to encode using printableString:
+        let ca1Name = try! DistinguishedName([
+            RelativeDistinguishedName([
+                RelativeDistinguishedName.Attribute(
+                    type: .RDNAttributeType.countryName,
+                    value: RelativeDistinguishedName.Attribute.Value(printableString: "US")
+                )
+            ]),
+            RelativeDistinguishedName([
+                RelativeDistinguishedName.Attribute(
+                    type: .RDNAttributeType.organizationName,
+                    value: RelativeDistinguishedName.Attribute.Value(printableString: "Apple")
+                )
+            ]),
+            RelativeDistinguishedName([
+                RelativeDistinguishedName.Attribute(
+                    type: .RDNAttributeType.commonName,
+                    value: RelativeDistinguishedName.Attribute.Value(printableString: "Swift Certificate Test CA 1")
+                )
+            ]),
+        ])
+        return try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(ca1PrivateKey.publicKey),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(3650),
+            issuer: ca1Name,
+            subject: ca1Name,
+            signatureAlgorithm: .ecdsaWithSHA384,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.isCertificateAuthority(maxPathLength: nil)
+                )
+                KeyUsage(keyCertSign: true)
+                SubjectKeyIdentifier(
+                    keyIdentifier: ArraySlice(Insecure.SHA1.hash(data: ca1PrivateKey.publicKey.derRepresentation))
+                )
+            },
+            issuerPrivateKey: .init(ca1PrivateKey)
+        )
+    }()
+
+    private static let leafPrivateKey = P256.Signing.PrivateKey()
+    private static let leafCert: Certificate = {
+        try! Certificate(
+            version: .v3,
+            serialNumber: .init(),
+            publicKey: .init(leafPrivateKey.publicKey),
+            notValidBefore: referenceTime - .days(365),
+            notValidAfter: referenceTime + .days(365),
+            // Force leaf to encode using utf8String:
+            issuer: DistinguishedName([
+                RelativeDistinguishedName([
+                    RelativeDistinguishedName.Attribute(
+                        type: .RDNAttributeType.countryName,
+                        value: RelativeDistinguishedName.Attribute.Value(utf8String: "US")
+                    )
+                ]),
+                RelativeDistinguishedName([
+                    RelativeDistinguishedName.Attribute(
+                        type: .RDNAttributeType.organizationName,
+                        value: RelativeDistinguishedName.Attribute.Value(utf8String: "Apple")
+                    )
+                ]),
+                RelativeDistinguishedName([
+                    RelativeDistinguishedName.Attribute(
+                        type: .RDNAttributeType.commonName,
+                        value: RelativeDistinguishedName.Attribute.Value(utf8String: "Swift Certificate Test CA 1")
+                    )
+                ]),
+            ]),
+            subject: try! DistinguishedName {
+                CountryName("US")
+                OrganizationName("Apple")
+                CommonName("localhost")
+            },
+            signatureAlgorithm: .ecdsaWithSHA256,
+            extensions: Certificate.Extensions {
+                Critical(
+                    BasicConstraints.notCertificateAuthority
+                )
+                KeyUsage(keyCertSign: true)
+                AuthorityKeyIdentifier(keyIdentifier: try! ca1.extensions.subjectKeyIdentifier!.keyIdentifier)
+            },
+            issuerPrivateKey: .init(ca1PrivateKey)
+        )
+    }()
+
+    func testCustomCertificateStore() async throws {
+        // MUST fail due to encoding of DN mismatch:
+        var concreteStore = CertificateStore()
+        concreteStore.append(Self.ca1)
+
+        var concreteVerifier = Verifier(rootCertificates: concreteStore) {
+            RFC5280Policy(validationTime: Date.now)
+        }
+        let concreteResult = await concreteVerifier.validate(
+            leafCertificate: Self.leafCert,
+            intermediates: CertificateStore()
+        )
+
+        guard case .couldNotValidate = concreteResult else {
+            XCTFail("Incorrectly validated: \(concreteResult)")
+            return
+        }
+
+        // The custom CertStore should normalize the DN so it no longer fails:
+        var customStore = CertificateStore(custom: CertStore([]))
+        customStore.append(Self.ca1)
+
+        var customVerifier = Verifier(rootCertificates: customStore) {
+            RFC5280Policy(validationTime: Date.now)
+        }
+        let customResult = await customVerifier.validate(
+            leafCertificate: Self.leafCert,
+            intermediates: CertificateStore()
+        )
+
+        guard case .validCertificate(_) = customResult else {
+            XCTFail("Failed to validate: \(customResult)")
+            return
+        }
+    }
 }
 
 extension CertificateStore.Resolved {
     var totalCertificateCount: Int {
-        self.systemTrustRoots.values.lazy.map(\.count).reduce(0, +)
-            + self.additionalTrustRoots.values.lazy.map(\.count).reduce(0, +)
+        if case .concrete(let inner) = self {
+            inner.systemTrustRoots.values.lazy.map(\.count).reduce(0, +)
+                + inner.additionalTrustRoots.values.lazy.map(\.count).reduce(0, +)
+        } else {
+            fatalError("Expected concrete certificate store!")
+        }
     }
 }


### PR DESCRIPTION
This change adds support for implementing a `CustomCertificateStore` in a backwards compatible way with minimal impact to performance. A custom certificate store can be implemented, and then the new `CertificateStore(custom:)` constructor can be used so that the custom certificate store can be used interchangeably with a "normal" certificate store.

Additionally, a test case verifies that this new protocol will work for our use case. More specifically, the use case we have is for normalization of distinguished names so that an exact match of distinguished names is no longer required. For example, if `printableString` should be used interchangeably with a `utf8String`.

This pull request has two commits:
- One that adds support for a `CustomCertificateStore`
- One that modifies the implementation to support `async` lookup of certificiates.

The second change is not required for our use-case, however I would expect that there may be a future use-case that requires looking up certificates in a database, and supporting an `async` protocol would be valuable. Also, the `verify()` method is already async, so supporting an `async` lookup does not disrupt any existing public APIs.