### PR TITLE
Support singing via Certificate PrivateKey

### DIFF
--- a/Sources/X509/CertificatePrivateKey.swift
+++ b/Sources/X509/CertificatePrivateKey.swift
@@ -91,8 +91,14 @@ extension Certificate {
         }
         #endif
 
+        /// Use the private key to sign the provided bytes with a given signature algorithm.
+        ///
+        /// - Parameters:
+        ///   - bytes: The data to create the signature for.
+        ///   - signatureAlgorithm: The signature algorithm to use.
+        /// - Returns: The signature.
         @inlinable
-        internal func sign<Bytes: DataProtocol>(
+        public func sign<Bytes: DataProtocol>(
             bytes: Bytes,
             signatureAlgorithm: SignatureAlgorithm
         ) throws -> Signature {

--- a/Sources/X509/Signature.swift
+++ b/Sources/X509/Signature.swift
@@ -132,18 +132,9 @@ extension Certificate.Signature {
 extension Certificate.Signature {
     /// The raw byte representation of the signature.
     @inlinable
-    public var rawRepresentation: [UInt8] {
-        switch backing {
-        case let .ecdsa(signature):
-            var serializer = DER.Serializer()
-            // we are serializing from raw bytes, force try is safe here
-            try! signature.serialize(into: &serializer, withIdentifier: ECDSASignature.defaultIdentifier)
-            return serializer.serializedBytes
-        case let .ed25519(data):
-            return .init(data)
-        case let .rsa(signature):
-            return .init(signature.rawRepresentation)
-        }
+    public var rawRepresentation: ArraySlice<UInt8> {
+        let bitString = ASN1BitString(self)
+        return bitString.bytes
     }
 }
 

--- a/Sources/X509/Signature.swift
+++ b/Sources/X509/Signature.swift
@@ -129,6 +129,25 @@ extension Certificate.Signature {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension Certificate.Signature {
+    /// The raw byte representation of the signature.
+    @inlinable
+    public var rawRepresentation: [UInt8] {
+        switch backing {
+        case let .ecdsa(signature):
+            var serializer = DER.Serializer()
+            // we are serializing from raw bytes, force try is safe here
+            try! signature.serialize(into: &serializer, withIdentifier: ECDSASignature.defaultIdentifier)
+            return serializer.serializedBytes
+        case let .ed25519(data):
+            return .init(data)
+        case let .rsa(signature):
+            return .init(signature.rawRepresentation)
+        }
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension ASN1BitString {
     @inlinable
     init(_ signature: Certificate.Signature) {

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -72,6 +72,18 @@ final class SignatureTests: XCTestCase {
         XCTAssertEqual(.init(expected), signature.rawRepresentation)
     }
 
+    func testECDSASignatureBytes() throws {
+        let input = Array("Hello World".utf8)
+
+        let expected = try Self.p384Key.signature(for: SHA256.hash(data: input))
+        let signature = try Certificate.Signature(
+            signatureAlgorithm: .ecdsaWithSHA256,
+            signatureBytes: .init(bytes: Array(expected.derRepresentation)[...])
+        )
+
+        XCTAssertEqual(.init(expected.derRepresentation), signature.rawRepresentation)
+    }
+
     func testP384Signature() throws {
         // This is the P384 signature over LetsEncrypt Intermediate E1.
         let signatureBytes: [UInt8] = [
@@ -97,7 +109,7 @@ final class SignatureTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(signature.rawRepresentation, signatureBytes)
+        XCTAssertEqual(signature.rawRepresentation, .init(signatureBytes))
 
         // Validate that the signature is valid over the TBS certificate bytes.
         let issuingPublicKeyBytes: [UInt8] = [

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -64,7 +64,10 @@ final class SignatureTests: XCTestCase {
         let input = Array("Hello World".utf8)
 
         let expected = try Self.ed25519Key.signature(for: input)
-        let signature = try Certificate.Signature(signatureAlgorithm: .ed25519, signatureBytes: .init(bytes: Array(expected)[...]))
+        let signature = try Certificate.Signature(
+            signatureAlgorithm: .ed25519,
+            signatureBytes: .init(bytes: Array(expected)[...])
+        )
 
         XCTAssertEqual(.init(expected), signature.rawRepresentation)
     }

--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -50,6 +50,25 @@ final class SignatureTests: XCTestCase {
     )
     #endif
 
+    func testRSASignatureBytes() throws {
+        let input = Array("Hello World".utf8)
+        let privateKey = Certificate.PrivateKey(Self.rsaKey)
+
+        let expected = try Self.rsaKey.signature(for: SHA256.hash(data: input), padding: .insecurePKCS1v1_5)
+        let found = try privateKey.sign(bytes: input, signatureAlgorithm: .sha256WithRSAEncryption)
+
+        XCTAssertEqual(.init(expected.rawRepresentation), found.rawRepresentation)
+    }
+
+    func testEd25519SignatureBytes() throws {
+        let input = Array("Hello World".utf8)
+
+        let expected = try Self.ed25519Key.signature(for: input)
+        let signature = try Certificate.Signature(signatureAlgorithm: .ed25519, signatureBytes: .init(bytes: Array(expected)[...]))
+
+        XCTAssertEqual(.init(expected), signature.rawRepresentation)
+    }
+
     func testP384Signature() throws {
         // This is the P384 signature over LetsEncrypt Intermediate E1.
         let signatureBytes: [UInt8] = [
@@ -74,6 +93,8 @@ final class SignatureTests: XCTestCase {
             XCTFail("Invalid signature decode")
             return
         }
+
+        XCTAssertEqual(signature.rawRepresentation, signatureBytes)
 
         // Validate that the signature is valid over the TBS certificate bytes.
         let issuingPublicKeyBytes: [UInt8] = [


### PR DESCRIPTION
This PR introduces two key changes to improve flexibility when working with signatures in swift-certificates. Previously, it was only possible to verify signatures using `Certificate.PrivateKey`, but not to generate them.

- The internal `sign(bytes:signatureAlgorithm:)` method on `Certificate.PrivateKey` is now public, allowing users to generate signatures directly.
- `Certificate.Signature` gains a new `rawRepresentation` property that exposes the raw byte representation of a signature.
