### PR TITLE
Fix API documentation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ dependencies: [
 ]
 ```
 
-For detailed usage and API documentation, check [the documentation](https://swiftpackageindex.com/apple/swift-certificates/main/documentation/x509).
+For detailed usage and API documentation, check [the documentation](https://swiftpackageindex.com/apple/swift-certificates/documentation/x509).
 
 ## Benchmarks
 


### PR DESCRIPTION
This PR removes `main` branch name from API docs URLs, making them always point to the latest stable release instead of the main branch.

For most of developers this README.md is the main entry point when installing the library, so pointing them to API docs for the latest stable release makes more sense then the main branch which may contain un-released API or breaking changes.