### PR TITLE
Testing kSecAttrAccessible value on macOS runners

### DIFF
--- a/Tests/X509Tests/SignatureTests.swift
+++ b/Tests/X509Tests/SignatureTests.swift
@@ -472,7 +472,7 @@ final class SignatureTests: XCTestCase {
     static func generateSecKey(keyType: CFString, keySize: Int, useSEP: Bool) throws -> SecKey {
         let access = SecAccessControlCreateWithFlags(
             kCFAllocatorDefault,
-            kSecAttrAccessibleAlwaysThisDeviceOnly,
+            kSecAttrAccessibleAlways,
             .privateKeyUsage,
             nil
         )!


### PR DESCRIPTION
Just testing the behavior of a different value of `test-kSecAttrAccessible` on the macOS runners.