### PR TITLE
[1.10.x] CMake: Use full module triples (#252)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,6 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-if(POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif()
-
-if(POLICY CMP0091)
-  cmake_policy(SET CMP0091 NEW)
-endif()
-
 cmake_minimum_required(VERSION 3.19)
 
 project(SwiftCertificates

--- a/cmake/modules/SwiftSupport.cmake
+++ b/cmake/modules/SwiftSupport.cmake
@@ -12,48 +12,17 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-# Returns the architecture name in a variable
-#
-# Usage:
-#   get_swift_host_arch(result_var_name)
-#
-# Sets ${result_var_name} with the converted architecture name derived from
-# CMAKE_SYSTEM_PROCESSOR.
-function(get_swift_host_arch result_var_name)
-  if("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86_64")
-    set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AArch64|aarch64|arm64|ARM64")
-    if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-      set("${result_var_name}" "arm64" PARENT_SCOPE)
-    else()
-      set("${result_var_name}" "aarch64" PARENT_SCOPE)
-    endif()
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64")
-    set("${result_var_name}" "powerpc64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "ppc64le")
-    set("${result_var_name}" "powerpc64le" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "s390x")
-    set("${result_var_name}" "s390x" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv6l")
-    set("${result_var_name}" "armv6" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7l")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "armv7-a")
-    set("${result_var_name}" "armv7" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "AMD64|amd64")
-    set("${result_var_name}" "x86_64" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "IA64")
-    set("${result_var_name}" "itanium" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "x86")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "i686")
-    set("${result_var_name}" "i686" PARENT_SCOPE)
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" STREQUAL "riscv64")
-    set("${result_var_name}" "riscv64" PARENT_SCOPE)
-  else()
-    message(FATAL_ERROR "Unrecognized architecture on host system: ${CMAKE_SYSTEM_PROCESSOR}")
+if(NOT SwiftCertificates_SWIFTMODULE_TRIPLE)
+  set(target_info_cmd "${CMAKE_Swift_COMPILER}" -print-target-info)
+  if(CMAKE_Swift_COMPILER_TARGET)
+    list(APPEND target_info_cmd -target ${CMAKE_Swift_COMPILER_TARGET})
   endif()
-endfunction()
+  execute_process(COMMAND ${target_info_cmd} OUTPUT_VARIABLE target_info)
+  string(JSON module_triple GET "${target_info}" "target" "moduleTriple")
+  set(SwiftCertificates_SWIFTMODULE_TRIPLE "${module_triple}" CACHE STRING "Triple used to install Swift module files")
+  mark_as_advanced(SwiftCertificates_SWIFTMODULE_TRIPLE)
+  message(CONFIGURE_LOG "Swift module triple: ${module_triple}")
+endif()
 
 # Returns the os name in a variable
 #
@@ -90,24 +59,15 @@ function(_install_target module)
     return()
   endif()
 
-  get_swift_host_arch(swift_arch)
   get_target_property(module_name ${module} Swift_MODULE_NAME)
   if(NOT module_name)
     set(module_name ${module})
   endif()
 
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-      RENAME ${swift_arch}.swiftdoc)
-    install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-      DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
-      RENAME ${swift_arch}.swiftmodule)
-  else()
-    install(FILES
-      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
-      $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
-      DESTINATION lib/${swift}/${swift_os}/${swift_arch})
-  endif()
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftdoc
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftCertificates_SWIFTMODULE_TRIPLE}.swiftdoc)
+  install(FILES $<TARGET_PROPERTY:${module},Swift_MODULE_DIRECTORY>/${module_name}.swiftmodule
+    DESTINATION lib/${swift}/${swift_os}/${module_name}.swiftmodule
+    RENAME ${SwiftCertificates_SWIFTMODULE_TRIPLE}.swiftmodule)
 endfunction()
-


### PR DESCRIPTION
Teach the CMake build to install swiftmodules using the full module triple. This uses the compiler to determine the appropriate module triple instead of attempting to compute the architecture in CMake script, making the build more robust for new platforms and architectures.

Also removing redundant policies. CMP0077 and CMP0091 were added before the minimum CMake version and therefore will always be active in this project.

(cherry picked from commit b77cbe9d98d0d119fb9597227e8570904b4df510)