### PR TITLE
Enable 5.9 CI explicitly in GitHub workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
+      linux_5_9_enabled: true
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -15,6 +15,7 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
+      linux_5_9_enabled: true
       linux_5_9_arguments_override: "--explicit-target-dependency-import-check error"
       linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"


### PR DESCRIPTION
## Motivation

We've created the `release/1.10.x` branch to backport some patches for 5.9. However, the CI there uses the workflows pulled from NIO main, which have since disabled 5.9 by default.

## Modifications

Enable 5.9 in the GitHub workflow on this branch.

## Result

5.9 CI on the `release/1.10.x` branch.