### PR TITLE
Add support for the current time to be obtained *at the point of validation* in `RFC5280Policy` and `OCSPPolicy`.

### DIFF
--- a/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/ExpiryPolicy.swift
@@ -27,15 +27,26 @@ struct ExpiryPolicy: VerifierPolicy {
     let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = []
 
     @usableFromInline
-    let validationTime: GeneralizedTime
+    let fixedValidationTime: GeneralizedTime?
 
+    /// Creates an instance with an optional *fixed* expiry validation time.
+    ///
+    /// - Parameter fixedValidationTime: The *fixed* time to compare against when determining if the certificates in the chain have expired. A fixed
+    ///   time is a *specific* time, either in the past or future, but **not** the current time. To compare against the current time *at the point of validation*,
+    ///   pass `nil` to `fixedValidationTime`.
+    ///
+    /// - Important: Pass `nil` to `fixedValidationTime` for the current time to be obtained at the time of validation and then used for the
+    ///   comparison; the validation method may be invoked long after initialization.
     @inlinable
-    init(validationTime: Date) {
-        self.validationTime = GeneralizedTime(validationTime)
+    init(fixedValidationTime: Date? = nil) {
+        self.fixedValidationTime = fixedValidationTime.map(GeneralizedTime.init)
     }
 
     @inlinable
     func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) -> PolicyEvaluationResult {
+        // Obtain the current time if self.fixedValidationTime is nil.
+        let validationTime = self.fixedValidationTime ?? GeneralizedTime(Date())
+
         // This is an easy check: confirm all the certs are valid.
         //
         // Note that we do this computation on the TBSCertificate Validity struct, not the public Date fields. This is
@@ -51,11 +62,11 @@ struct ExpiryPolicy: VerifierPolicy {
                 )
             }
 
-            if self.validationTime < notValidBefore {
+            if validationTime < notValidBefore {
                 return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) is not yet valid")
             }
 
-            if self.validationTime > notValidAfter {
+            if validationTime > notValidAfter {
                 return .failsToMeetPolicy(reason: "RFC5280Policy: Certificate \(cert) has expired")
             }
         }

--- a/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
+++ b/Sources/X509/Verifier/RFC5280/RFC5280Policy.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -56,9 +56,23 @@ public struct RFC5280Policy: VerifierPolicy {
     let nameConstraintsPolicy: NameConstraintsPolicy
 
     @inlinable
+    @available(*, deprecated, renamed: "init(fixedValidationTime:)", message: "Use init(fixedValidationTime:) instead.")
     public init(validationTime: Date) {
+        self.init(fixedValidationTime: validationTime)
+    }
+
+    /// Creates an instance with an optional *fixed* expiry validation time.
+    ///
+    /// - Parameter fixedValidationTime: The *fixed* time to compare against when determining if the certificates in the chain have expired. A fixed
+    ///   time is a *specific* time, either in the past or future, but **not** the current time. To compare against the current time *at the point of validation*,
+    ///   pass `nil` to `fixedValidationTime`.
+    ///
+    /// - Important: Pass `nil` to `fixedValidationTime` for the current time to be obtained at the time of validation and then used for the
+    ///   comparison; the validation method may be invoked long after initialization.
+    @inlinable
+    public init(fixedValidationTime: Date? = nil) {
         self.versionPolicy = VersionPolicy()
-        self.expiryPolicy = ExpiryPolicy(validationTime: validationTime)
+        self.expiryPolicy = ExpiryPolicy(fixedValidationTime: fixedValidationTime)
         self.basicConstraintsPolicy = BasicConstraintsPolicy()
         self.nameConstraintsPolicy = NameConstraintsPolicy()
     }

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -176,7 +176,7 @@ final class CMSTests: XCTestCase {
     )
 
     @PolicyBuilder static var defaultPolicies: some VerifierPolicy {
-        RFC5280Policy(validationTime: Date())
+        RFC5280Policy()
     }
 
     private func assertRoundTrips<ASN1Object: DERParseable & DERSerializable & Equatable>(_ value: ASN1Object) throws {

--- a/Tests/X509Tests/CertificateDERTests.swift
+++ b/Tests/X509Tests/CertificateDERTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -543,7 +543,7 @@ final class CertificateDERTests: XCTestCase {
         // And we should be able to validate it.
         let roots = CertificateStore([issuer])
         var verifier = Verifier(rootCertificates: roots) {
-            RFC5280Policy(validationTime: now + 1)
+            RFC5280Policy(fixedValidationTime: now + 1)
         }
         let result = await verifier.validate(leafCertificate: parsed, intermediates: CertificateStore())
 

--- a/Tests/X509Tests/CertificateStore.swift
+++ b/Tests/X509Tests/CertificateStore.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -207,7 +207,7 @@ final class CertificateStoreTests: XCTestCase {
         concreteStore.append(Self.ca1)
 
         var concreteVerifier = Verifier(rootCertificates: concreteStore) {
-            RFC5280Policy(validationTime: Date.now)
+            RFC5280Policy()
         }
         let concreteResult = await concreteVerifier.validate(
             leafCertificate: Self.leafCert,
@@ -224,7 +224,7 @@ final class CertificateStoreTests: XCTestCase {
         customStore.append(Self.ca1)
 
         var customVerifier = Verifier(rootCertificates: customStore) {
-            RFC5280Policy(validationTime: Date.now)
+            RFC5280Policy()
         }
         let customResult = await customVerifier.validate(
             leafCertificate: Self.leafCert,

--- a/Tests/X509Tests/PolicyBuilderTests.swift
+++ b/Tests/X509Tests/PolicyBuilderTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2023 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -408,7 +408,7 @@ final class PolicyBuilderTests: XCTestCase {
         // tested at compile time
         let _: Verifier<AnyPolicy> = Verifier(rootCertificates: CertificateStore()) {
             AnyPolicy {
-                RFC5280Policy(validationTime: Date())
+                RFC5280Policy()
             }
         }
     }

--- a/Tests/X509Tests/VerifierTests.swift
+++ b/Tests/X509Tests/VerifierTests.swift
@@ -2,7 +2,7 @@
 //
 // This source file is part of the SwiftCertificates open source project
 //
-// Copyright (c) 2022 Apple Inc. and the SwiftCertificates project authors
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
 // Licensed under Apache License v2.0
 //
 // See LICENSE.txt for license information
@@ -541,7 +541,7 @@ final class VerifierTests: XCTestCase {
     }()
 
     @PolicyBuilder private static var defaultPolicy: some VerifierPolicy {
-        RFC5280Policy(validationTime: referenceTime)
+        RFC5280Policy(fixedValidationTime: referenceTime)
     }
 
     func testTrivialChainBuilding() async throws {


### PR DESCRIPTION
Add support for the current time to be obtained *at the point of validation* and used as the validation time in `RFC5280Policy` and `OCSPPolicy`.

## Motivation:

The initializers of `RFC5280Policy` and `OCSPPolicy` require a validation time as an argument. If this argument is set to `Date.now`, the timestamp would be captured at the point of initialization. As such, if the validation method is invoked on the policy instance long after initialization, the timestamp can become stale at that point. This means that the validation function could incorrectly determine a certificate (`RFC5280Policy`) or an OCSP response (`OCSPPolicy`) to be valid, when it has actually expired by the time the validation is performed.  

This is not an issue in common use-cases where the policy is initialized (with `validationTime` set to `.now`) inside a `PolicyBuilder` closure, because the closure is evaluated at the point of validation. However, some use-cases may initialize the policy independently; the issue can potentially arise here.

## Modifications:

This patch deprecates the current initializers of `RFC5280Policy` and `OCSPPolicy` to guide users toward using a safer initializer which requires a `fixedValidationTime: Date?` argument:
- Passing `nil` (default) will lead to the current time being obtained *at the point of validation*. This will prevent the bug described above.
- Passing a specific `Date` instance preserves the ability to validate against a fixed point in time, i.e. a time in the past or future, but *not* the current time.

## Result:

Users now have the option to use a safer initializer to construct `RFC5280Policy` and `OCSPPolicy`.