### PR TITLE
Support generating CMS with trusted signing time

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -80,6 +80,82 @@ public enum CMS: Sendable {
     }
 
     @inlinable
+    static func buildSignedAttributes<Bytes: DataProtocol>(
+        for bytes: Bytes,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        signingTime: Date
+    ) throws -> [CMSAttribute] {
+        // 1. content-type attribute
+        let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
+        let contentTypeAttribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
+
+        // 2. message-digest attribute
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        let computedDigest = try Digest.computeDigest(for: bytes, using: digestAlgorithm)
+        let messageDigest = ASN1OctetString(contentBytes: ArraySlice(computedDigest))
+        let messageDigestVal = try ASN1Any(erasing: messageDigest)
+        let messageDigestAttribute = CMSAttribute(attrType: .messageDigest, attrValues: [messageDigestVal])
+
+        // add signing time utc time in 'YYMMDDHHMMSSZ' format as specificed in `UTCTime`
+        let utcTime = try UTCTime(signingTime.utcDate)
+        let signingTimeAttrVal = try ASN1Any(erasing: utcTime)
+        let signingTimeAttribute = CMSAttribute(attrType: .signingTime, attrValues: [signingTimeAttrVal])
+        return [contentTypeAttribute, messageDigestAttribute, signingTimeAttribute]
+    }
+
+    @_spi(CMS)
+    @inlinable
+    public static func getSignedAttributesBytes<Data: DataProtocol>(
+        digest: Data,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        signingTime: Date
+    ) throws -> [UInt8] {
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: digest,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
+        var coder = DER.Serializer()
+        try coder.serializeSetOf(signedAttrs)
+        return coder.serializedBytes
+    }
+
+    @_spi(CMS)
+    @inlinable
+    public static func signWithTrustedTimestamp<Data: DataProtocol>(
+        _ bytes: Data,
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        additionalIntermediateCertificates: [Certificate] = [],
+        certificate: Certificate,
+        signingTime: Date,
+        detached: Bool = true,
+        trustedTimestampBytes: [UInt8]
+    ) throws -> [UInt8] {
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: bytes,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
+        // Adding trusted timestamp to unsignedAttrs
+        let tsrWrapped = try ASN1Any(derEncoded: trustedTimestampBytes)
+        let timestampAttr = CMSAttribute(attrType: .trustedTimestamp, attrValues: [tsrWrapped])
+        let unsignedAttrs: [CMSAttribute] = [timestampAttr]
+
+        // Generating CMS
+        let signedData = try self.generateSignedDataWithUnsignedAttrs(
+            signatureBytes: signatureBytes,
+            signatureAlgorithm: signatureAlgorithm,
+            additionalIntermediateCertificates: additionalIntermediateCertificates,
+            certificate: certificate,
+            signedAttrs: signedAttrs,
+            withContent: detached ? nil : bytes,
+            unsignedAttrs: unsignedAttrs
+        )
+        return try self.serializeSignedData(signedData)
+    }
+
+    @inlinable
     static func signWithSigningTime<Bytes: DataProtocol>(
         _ bytes: Bytes,
         signatureAlgorithm: Certificate.SignatureAlgorithm,
@@ -89,30 +165,11 @@ public enum CMS: Sendable {
         signingTime: Date,
         detached: Bool = true
     ) throws -> [UInt8] {
-        var signedAttrs: [CMSAttribute] = []
-        // As specified in RFC 5652 section 11 when including signedAttrs we need to include a minimum of:
-        // 1. content-type
-        // 2. message-digest
-
-        // add content-type signedAttr cms data
-        let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
-        let contentTypeAttribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
-        signedAttrs.append(contentTypeAttribute)
-
-        // add message-digest of provided content bytes
-        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
-        let computedDigest = try Digest.computeDigest(for: bytes, using: digestAlgorithm)
-        let messageDigest = ASN1OctetString(contentBytes: ArraySlice(computedDigest))
-        let messageDigestVal = try ASN1Any(erasing: messageDigest)
-        let messageDigestAttr = CMSAttribute(attrType: .messageDigest, attrValues: [messageDigestVal])
-        signedAttrs.append(messageDigestAttr)
-
-        // add signing time utc time in 'YYMMDDHHMMSSZ' format as specificed in `UTCTime`
-        let utcTime = try UTCTime(signingTime.utcDate)
-        let signingTimeAttrVal = try ASN1Any(erasing: utcTime)
-        let signingTimeAttribute = CMSAttribute(attrType: .signingTime, attrValues: [signingTimeAttrVal])
-        signedAttrs.append(signingTimeAttribute)
-
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: bytes,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
         // As specified in RFC 5652 section 5.4:
         // When the [signedAttrs] field is present, however, the result is the message digest of the complete DER encoding of the SignedAttrs value contained in the signedAttrs field.
         var coder = DER.Serializer()
@@ -174,6 +231,46 @@ public enum CMS: Sendable {
             signedAttrs: signedAttrs,
             withContent: nil as Data?
         )
+    }
+
+    @inlinable
+    static func generateSignedDataWithUnsignedAttrs<Bytes: DataProtocol>(
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        additionalIntermediateCertificates: [Certificate],
+        certificate: Certificate,
+        signedAttrs: [CMSAttribute]? = nil,
+        withContent content: Bytes? = nil,
+        unsignedAttrs: [CMSAttribute]? = nil
+    ) throws -> CMSContentInfo {
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        var contentInfo = CMSEncapsulatedContentInfo(eContentType: .cmsData)
+        if let content {
+            contentInfo.eContent = ASN1OctetString(contentBytes: Array(content)[...])
+        }
+
+        let signerInfo = CMSSignerInfo(
+            // TODO: Megalith uses .init(subjectKeyIdentifier: certificate). Check with SEAR which one to use
+            signerIdentifier: .init(issuerAndSerialNumber: certificate),
+            digestAlgorithm: digestAlgorithm,
+            signedAttrs: signedAttrs,
+            signatureAlgorithm: AlgorithmIdentifier(signatureAlgorithm),
+            signature: signatureBytes,
+            unsignedAttrs: unsignedAttrs
+        )
+
+
+        var certificates = [certificate]
+        certificates.append(contentsOf: additionalIntermediateCertificates)
+
+        let signedData = CMSSignedData(
+            version: .v3,  // Signed Data should be v3
+            digestAlgorithms: [digestAlgorithm],
+            encapContentInfo: contentInfo,
+            certificates: certificates,
+            signerInfos: [signerInfo]
+        )
+        return try CMSContentInfo(signedData)
     }
 
     @inlinable

--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -80,6 +80,81 @@ public enum CMS: Sendable {
     }
 
     @inlinable
+    static func buildSignedAttributes<Bytes: DataProtocol>(
+        for bytes: Bytes,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        signingTime: Date
+    ) throws -> [CMSAttribute] {
+        // 1. content-type attribute
+        let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
+        let contentTypeAttribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
+
+        // 2. message-digest attribute
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        let computedDigest = try Digest.computeDigest(for: bytes, using: digestAlgorithm)
+        let messageDigest = ASN1OctetString(contentBytes: ArraySlice(computedDigest))
+        let messageDigestVal = try ASN1Any(erasing: messageDigest)
+        let messageDigestAttribute = CMSAttribute(attrType: .messageDigest, attrValues: [messageDigestVal])
+
+        // add signing time utc time in 'YYMMDDHHMMSSZ' format as specificed in `UTCTime`
+        let utcTime = try UTCTime(signingTime.utcDate)
+        let signingTimeAttrVal = try ASN1Any(erasing: utcTime)
+        let signingTimeAttribute = CMSAttribute(attrType: .signingTime, attrValues: [signingTimeAttrVal])
+        return [contentTypeAttribute, messageDigestAttribute, signingTimeAttribute]
+    }
+
+    @inlinable
+    public static func getSignedAttributesBytes<Data: DataProtocol>(
+        digest: Data,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        signingTime: Date
+    ) throws -> [UInt8] {
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: digest,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
+        var coder = DER.Serializer()
+        try coder.serializeSetOf(signedAttrs)
+        return coder.serializedBytes
+    }
+
+    @_spi(CMS)
+    @inlinable
+    public static func signWithTrustedTimestamp<Data: DataProtocol>(
+        _ bytes: Data,
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        additionalIntermediateCertificates: [Certificate] = [],
+        certificate: Certificate,
+        signingTime: Date,
+        detached: Bool = true,
+        trustedTimestampBytes: [UInt8]
+    ) throws -> [UInt8] {
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: bytes,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
+        // Adding trusted timestamp to unsignedAttrs
+        let tsrWrapped = try ASN1Any(derEncoded: trustedTimestampBytes)
+        let timestampAttr = CMSAttribute(attrType: .trustedTimestamp, attrValues: [tsrWrapped])
+        let unsignedAttrs: [CMSAttribute] = [timestampAttr]
+
+        // Generating CMS
+        let signedData = try self.generateSignedDataWithUnsignedAttrs(
+            signatureBytes: signatureBytes,
+            signatureAlgorithm: signatureAlgorithm,
+            additionalIntermediateCertificates: additionalIntermediateCertificates,
+            certificate: certificate,
+            signedAttrs: signedAttrs,
+            withContent: detached ? nil : bytes,
+            unsignedAttrs: unsignedAttrs
+        )
+        return try self.serializeSignedData(signedData)
+    }
+
+    @inlinable
     static func signWithSigningTime<Bytes: DataProtocol>(
         _ bytes: Bytes,
         signatureAlgorithm: Certificate.SignatureAlgorithm,
@@ -89,30 +164,11 @@ public enum CMS: Sendable {
         signingTime: Date,
         detached: Bool = true
     ) throws -> [UInt8] {
-        var signedAttrs: [CMSAttribute] = []
-        // As specified in RFC 5652 section 11 when including signedAttrs we need to include a minimum of:
-        // 1. content-type
-        // 2. message-digest
-
-        // add content-type signedAttr cms data
-        let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
-        let contentTypeAttribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
-        signedAttrs.append(contentTypeAttribute)
-
-        // add message-digest of provided content bytes
-        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
-        let computedDigest = try Digest.computeDigest(for: bytes, using: digestAlgorithm)
-        let messageDigest = ASN1OctetString(contentBytes: ArraySlice(computedDigest))
-        let messageDigestVal = try ASN1Any(erasing: messageDigest)
-        let messageDigestAttr = CMSAttribute(attrType: .messageDigest, attrValues: [messageDigestVal])
-        signedAttrs.append(messageDigestAttr)
-
-        // add signing time utc time in 'YYMMDDHHMMSSZ' format as specificed in `UTCTime`
-        let utcTime = try UTCTime(signingTime.utcDate)
-        let signingTimeAttrVal = try ASN1Any(erasing: utcTime)
-        let signingTimeAttribute = CMSAttribute(attrType: .signingTime, attrValues: [signingTimeAttrVal])
-        signedAttrs.append(signingTimeAttribute)
-
+        let signedAttrs: [CMSAttribute] = try buildSignedAttributes(
+            for: bytes,
+            signatureAlgorithm: signatureAlgorithm,
+            signingTime: signingTime
+        )
         // As specified in RFC 5652 section 5.4:
         // When the [signedAttrs] field is present, however, the result is the message digest of the complete DER encoding of the SignedAttrs value contained in the signedAttrs field.
         var coder = DER.Serializer()
@@ -174,6 +230,45 @@ public enum CMS: Sendable {
             signedAttrs: signedAttrs,
             withContent: nil as Data?
         )
+    }
+
+    @inlinable
+    static func generateSignedDataWithUnsignedAttrs<Bytes: DataProtocol>(
+        signatureBytes: ASN1OctetString,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        additionalIntermediateCertificates: [Certificate],
+        certificate: Certificate,
+        signedAttrs: [CMSAttribute]? = nil,
+        withContent content: Bytes? = nil,
+        unsignedAttrs: [CMSAttribute]? = nil
+    ) throws -> CMSContentInfo {
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        var contentInfo = CMSEncapsulatedContentInfo(eContentType: .cmsData)
+        if let content {
+            contentInfo.eContent = ASN1OctetString(contentBytes: Array(content)[...])
+        }
+
+        let signerInfo = CMSSignerInfo(
+            // TODO: Megalith uses .init(subjectKeyIdentifier: certificate). Check with SEAR which one to use
+            signerIdentifier: .init(issuerAndSerialNumber: certificate),
+            digestAlgorithm: digestAlgorithm,
+            signedAttrs: signedAttrs,
+            signatureAlgorithm: AlgorithmIdentifier(signatureAlgorithm),
+            signature: signatureBytes,
+            unsignedAttrs: unsignedAttrs
+        )
+
+        var certificates = [certificate]
+        certificates.append(contentsOf: additionalIntermediateCertificates)
+
+        let signedData = CMSSignedData(
+            version: .v3,  // Signed Data should be v3
+            digestAlgorithms: [digestAlgorithm],
+            encapContentInfo: contentInfo,
+            certificates: certificates,
+            signerInfos: [signerInfo]
+        )
+        return try CMSContentInfo(signedData)
     }
 
     @inlinable

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -291,5 +291,8 @@ extension ASN1ObjectIdentifier {
     static let signingTime: Self = [1, 2, 840, 113549, 1, 9, 5]
 
     @usableFromInline
+    static let trustedTimestamp: Self = [1, 2, 840, 113549, 1, 9, 16, 2, 14]
+
+    @usableFromInline
     static let contentType: Self = [1, 2, 840, 113549, 1, 9, 3]
 }

--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -137,7 +137,7 @@ struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Se
                 node in
                 return try DER.set(
                     of: CMSAttribute.self,
-                    identifier: .init(tagWithNumber: 0, tagClass: .contextSpecific),
+                    identifier: .init(tagWithNumber: 1, tagClass: .contextSpecific),
                     rootNode: node
                 )
             }
@@ -192,7 +192,7 @@ struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Se
                 node in
                 return try BER.set(
                     of: CMSAttribute.self,
-                    identifier: .init(tagWithNumber: 0, tagClass: .contextSpecific),
+                    identifier: .init(tagWithNumber: 1, tagClass: .contextSpecific),
                     rootNode: node
                 )
             }

--- a/Sources/X509/Digests.swift
+++ b/Sources/X509/Digests.swift
@@ -19,28 +19,38 @@ import Foundation
 #endif
 @preconcurrency import Crypto
 
-@usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-enum Digest: Sendable {
-    case insecureSHA1(Insecure.SHA1Digest)
-    case sha256(SHA256Digest)
-    case sha384(SHA384Digest)
-    case sha512(SHA512Digest)
+public struct Digest: Sendable {
+    @usableFromInline
+    enum Backing: Sendable {
+        case insecureSHA1(Insecure.SHA1Digest)
+        case sha256(SHA256Digest)
+        case sha384(SHA384Digest)
+        case sha512(SHA512Digest)
+    }
+
+    @usableFromInline
+    var backing: Backing
 
     @inlinable
-    static func computeDigest<Bytes: DataProtocol>(
+    init(_ backing: Backing) {
+        self.backing = backing
+    }
+
+    @inlinable
+    public static func computeDigest<Bytes: DataProtocol>(
         for bytes: Bytes,
         using digestIdentifier: AlgorithmIdentifier
     ) throws -> Digest {
         switch digestIdentifier {
         case .sha1, .sha1UsingNil:
-            return .insecureSHA1(Insecure.SHA1.hash(data: bytes))
+            return Digest(.insecureSHA1(Insecure.SHA1.hash(data: bytes)))
         case .sha256, .sha256UsingNil:
-            return .sha256(SHA256.hash(data: bytes))
+            return Digest(.sha256(SHA256.hash(data: bytes)))
         case .sha384, .sha384UsingNil:
-            return .sha384(SHA384.hash(data: bytes))
+            return Digest(.sha384(SHA384.hash(data: bytes)))
         case .sha512, .sha512UsingNil:
-            return .sha512(SHA512.hash(data: bytes))
+            return Digest(.sha512(SHA512.hash(data: bytes)))
         default:
             throw CertificateError.unsupportedDigestAlgorithm(reason: "Unknown digest algorithm: \(digestIdentifier)")
         }
@@ -49,9 +59,8 @@ enum Digest: Sendable {
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension Digest: Sequence {
-    @usableFromInline
-    func makeIterator() -> some IteratorProtocol<UInt8> {
-        switch self {
+    public func makeIterator() -> some IteratorProtocol<UInt8> {
+        switch self.backing {
         case .insecureSHA1(let sha1):
             return sha1.makeIterator()
         case .sha256(let sha256):

--- a/Sources/X509/SignatureAlgorithm.swift
+++ b/Sources/X509/SignatureAlgorithm.swift
@@ -133,7 +133,7 @@ extension AlgorithmIdentifier {
     }
 
     @inlinable
-    init(digestAlgorithmFor signatureAlgorithm: Certificate.SignatureAlgorithm) throws {
+    public init(digestAlgorithmFor signatureAlgorithm: Certificate.SignatureAlgorithm) throws {
         // Per RFC 5754 § 2, we must produce digest algorithm identifiers with
         // absent parameters, so we do.
         switch signatureAlgorithm {

--- a/Sources/X509/X509BaseTypes/AlgorithmIdentifier.swift
+++ b/Sources/X509/X509BaseTypes/AlgorithmIdentifier.swift
@@ -14,27 +14,23 @@
 
 import SwiftASN1
 
-@usableFromInline
-struct AlgorithmIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
+public struct AlgorithmIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Sendable {
     @inlinable
-    static var defaultIdentifier: ASN1Identifier {
+    public static var defaultIdentifier: ASN1Identifier {
         .sequence
     }
 
-    @usableFromInline
-    var algorithm: ASN1ObjectIdentifier
+    public var algorithm: ASN1ObjectIdentifier
 
-    @usableFromInline
-    var parameters: ASN1Any?
+    public var parameters: ASN1Any?
 
-    @inlinable
-    init(algorithm: ASN1ObjectIdentifier, parameters: ASN1Any?) {
+    public init(algorithm: ASN1ObjectIdentifier, parameters: ASN1Any?) {
         self.algorithm = algorithm
         self.parameters = parameters
     }
 
     @inlinable
-    init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
+    public init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         // The AlgorithmIdentifier block looks like this.
         //
         // AlgorithmIdentifier  ::=  SEQUENCE  {
@@ -51,12 +47,12 @@ struct AlgorithmIdentifier: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashab
     }
 
     @inlinable
-    init(berEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
+    public init(berEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         self = try .init(derEncoded: rootNode, withIdentifier: identifier)
     }
 
     @inlinable
-    func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
+    public func serialize(into coder: inout DER.Serializer, withIdentifier identifier: ASN1Identifier) throws {
         try coder.appendConstructedNode(identifier: identifier) { coder in
             try coder.serialize(self.algorithm)
             if let parameters = self.parameters {
@@ -216,8 +212,7 @@ extension AlgorithmIdentifier {
 }
 
 extension AlgorithmIdentifier: CustomStringConvertible {
-    @usableFromInline
-    var description: String {
+    public var description: String {
         switch self {
         case .p256PublicKey:
             return "p256PublicKey"

--- a/Tests/X509Tests/CMSSignerInfoUnsignedAttributesRoundTripTest.swift
+++ b/Tests/X509Tests/CMSSignerInfoUnsignedAttributesRoundTripTest.swift
@@ -1,0 +1,45 @@
+import XCTest
+import SwiftASN1
+@testable @_spi(CMS) import X509
+
+final class CMSSignerInfoUnsignedAttributesRoundTripTest: XCTestCase
+{
+    private func assertRoundTrips<ASN1Object: DERParseable & DERSerializable & Equatable>(_ value: ASN1Object)
+        throws
+    {
+        var serializer = DER.Serializer()
+        try serializer.serialize(value)
+        let parsed = try ASN1Object(derEncoded: serializer.serializedBytes)
+        XCTAssertEqual(parsed, value)
+    }
+
+    func testCMSSignerInfoWithUnsignedAttrsRoundTrips()
+        throws
+    {
+        // A SignerInfo carrying unsignedAttrs must survive a serialize/parse round trip.
+        // This exercises the `[1] IMPLICIT` unsignedAttrs path.
+        let unsignedAttr = CMSAttribute(
+            attrType: .contentType,
+            attrValues: [try ASN1Any(erasing: ASN1OctetString(contentBytes: [0xDE, 0xAD, 0xBE, 0xEF]))]
+        )
+        try assertRoundTrips(
+            CMSSignerInfo(
+                version: .v1,
+                signerIdentifier: .issuerAndSerialNumber(
+                    .init(
+                        issuer: .init {
+                            CountryName("US")
+                            OrganizationName("Apple Inc.")
+                            CommonName("Apple Public EV Server ECC CA 1 - G1")
+                        },
+                        serialNumber: .init(bytes: [20, 30, 40, 50])
+                    )
+                ),
+                digestAlgorithm: .sha256WithRSAEncryptionUsingNil,
+                signatureAlgorithm: .ecdsaWithSHA256,
+                signature: .init(contentBytes: [100, 110, 120, 130, 140]),
+                unsignedAttrs: [unsignedAttr]
+            )
+        )
+    }
+}

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -280,6 +280,34 @@ final class CMSTests: XCTestCase {
             "unexpected signerIdentifier for version should throw"
         )
     }
+
+    func testCMSSignerInfoWithUnsignedAttrsRoundTrips() throws {
+        // A SignerInfo carrying unsignedAttrs (e.g. a trusted timestamp) must survive a
+        // serialize/parse round trip. This exercises the `[1] IMPLICIT` unsignedAttrs path.
+        let trustedTimestamp = CMSAttribute(
+            attrType: .trustedTimestamp,
+            attrValues: [try ASN1Any(erasing: ASN1OctetString(contentBytes: [0xDE, 0xAD, 0xBE, 0xEF]))]
+        )
+        try assertRoundTrips(
+            CMSSignerInfo(
+                version: .v1,
+                signerIdentifier: .issuerAndSerialNumber(
+                    .init(
+                        issuer: .init {
+                            CountryName("US")
+                            OrganizationName("Apple Inc.")
+                            CommonName("Apple Public EV Server ECC CA 1 - G1")
+                        },
+                        serialNumber: .init(bytes: [20, 30, 40, 50])
+                    )
+                ),
+                digestAlgorithm: .sha256WithRSAEncryptionUsingNil,
+                signatureAlgorithm: .ecdsaWithSHA256,
+                signature: .init(contentBytes: [100, 110, 120, 130, 140]),
+                unsignedAttrs: [trustedTimestamp]
+            )
+        )
+    }
     func testEncapsulatedContentInfo() throws {
         try assertRoundTrips(
             CMSEncapsulatedContentInfo(
@@ -460,6 +488,76 @@ final class CMSTests: XCTestCase {
                 .foundValidCertificateChain([Self.leaf1Cert, Self.rootCert]),
             ]
         )
+    }
+
+    func testGetSignedAttributesBytesContainsRequiredAttributes() throws {
+        let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let signingTime = Date()
+
+        let signedAttributesBytes = try CMS.getSignedAttributesBytes(
+            digest: data,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            signingTime: signingTime
+        )
+
+        // The bytes are the DER encoding of a SET OF the required signed attributes:
+        // content-type, message-digest and signing-time (RFC 5652 § 11).
+        let rootNode = try DER.parse(signedAttributesBytes)
+        let attributes = try DER.set(of: CMSAttribute.self, identifier: .set, rootNode: rootNode)
+        XCTAssertEqual(
+            Set(attributes.map(\.attrType)),
+            [.contentType, .messageDigest, .signingTime]
+        )
+    }
+
+    func testSignWithTrustedTimestamp() async throws {
+        let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let signingTime = Date()
+
+        // Externally produce the signature over the signed attributes, as a remote or
+        // HSM-backed signer would.
+        let signedAttributesBytes = try CMS.getSignedAttributesBytes(
+            digest: data,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            signingTime: signingTime
+        )
+        let signature = try Self.leaf1Key.sign(
+            bytes: signedAttributesBytes[...],
+            signatureAlgorithm: .ecdsaWithSHA256
+        )
+
+        // The trusted-timestamp token is opaque to CMS; any valid DER is sufficient here.
+        var timestampSerializer = DER.Serializer()
+        try timestampSerializer.serialize(ASN1OctetString(contentBytes: [0xDE, 0xAD, 0xBE, 0xEF]))
+        let trustedTimestampBytes = timestampSerializer.serializedBytes
+
+        let cms = try CMS.signWithTrustedTimestamp(
+            data,
+            signatureBytes: ASN1OctetString(signature),
+            signatureAlgorithm: .ecdsaWithSHA256,
+            certificate: Self.leaf1Cert,
+            signingTime: signingTime,
+            trustedTimestampBytes: trustedTimestampBytes
+        )
+
+        // The produced CMS must carry the trusted timestamp as an unsigned attribute.
+        let contentInfo = try CMSContentInfo(derEncoded: cms)
+        let signedData = try CMSSignedData(asn1Any: contentInfo.content)
+        let signerInfo = try XCTUnwrap(signedData.signerInfos.first)
+        let unsignedAttrs = try XCTUnwrap(signerInfo.unsignedAttrs)
+        XCTAssertEqual(unsignedAttrs.map(\.attrType), [.trustedTimestamp])
+        XCTAssertEqual(
+            unsignedAttrs.first?.attrValues.first,
+            try ASN1Any(derEncoded: trustedTimestampBytes)
+        )
+
+        // And it must verify as a valid detached signature over the original data.
+        let isValidSignature = await CMS.isValidSignature(
+            dataBytes: data,
+            signatureBytes: cms,
+            trustRoots: CertificateStore([Self.rootCert])
+        ) { Self.defaultPolicies }
+        XCTAssertValidSignature(isValidSignature)
     }
 
     func testForbidsDetachedSignatureVerifyingAsAttached() async throws {

--- a/Tests/X509Tests/DigestsTests.swift
+++ b/Tests/X509Tests/DigestsTests.swift
@@ -1,0 +1,69 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import XCTest
+import Crypto
+import SwiftASN1
+@testable import X509
+
+final class DigestsTests: XCTestCase {
+    private static let message: [UInt8] = Array("The quick brown fox jumps over the lazy dog".utf8)
+
+    func testComputeDigestSHA256MatchesCrypto() throws {
+        let algorithm = try AlgorithmIdentifier(digestAlgorithmFor: .ecdsaWithSHA256)
+        let digest = try Digest.computeDigest(for: Self.message, using: algorithm)
+        XCTAssertEqual(Array(digest), Array(SHA256.hash(data: Self.message)))
+    }
+
+    func testComputeDigestSHA384MatchesCrypto() throws {
+        let algorithm = try AlgorithmIdentifier(digestAlgorithmFor: .ecdsaWithSHA384)
+        let digest = try Digest.computeDigest(for: Self.message, using: algorithm)
+        XCTAssertEqual(Array(digest), Array(SHA384.hash(data: Self.message)))
+    }
+
+    func testComputeDigestSHA512MatchesCrypto() throws {
+        let algorithm = try AlgorithmIdentifier(digestAlgorithmFor: .ecdsaWithSHA512)
+        let digest = try Digest.computeDigest(for: Self.message, using: algorithm)
+        XCTAssertEqual(Array(digest), Array(SHA512.hash(data: Self.message)))
+    }
+
+    func testComputeDigestSHA1MatchesCrypto() throws {
+        let algorithm = try AlgorithmIdentifier(digestAlgorithmFor: .sha1WithRSAEncryption)
+        let digest = try Digest.computeDigest(for: Self.message, using: algorithm)
+        XCTAssertEqual(Array(digest), Array(Insecure.SHA1.hash(data: Self.message)))
+    }
+
+    func testComputeDigestRejectsNonDigestAlgorithm() throws {
+        // `rsaKey` is a key algorithm, not a digest algorithm, so it must be rejected.
+        XCTAssertThrowsError(try Digest.computeDigest(for: Self.message, using: .rsaKey)) { error in
+            guard let error = error as? CertificateError else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+            XCTAssertEqual(error.code, .unsupportedDigestAlgorithm)
+        }
+    }
+
+    func testDigestSequenceIsStable() throws {
+        // Iterating the digest twice must yield the same bytes each time.
+        let algorithm = try AlgorithmIdentifier(digestAlgorithmFor: .ecdsaWithSHA256)
+        let digest = try Digest.computeDigest(for: Self.message, using: algorithm)
+        XCTAssertEqual(Array(digest), Array(digest))
+    }
+}


### PR DESCRIPTION
Motivation:

We had a need to generate CMS structures with an embedded trusted timestamp that indicates the time at which a signing operation was performed, and discovered that this was not supported by the existing Swift Certificates implementation.

Modifications:

To address this need, we adapted existing functionality, adding several functions allowing the signing time to be embedded in a CMS structure.

In order to make this work, we also needed to add public access to several entities in the code.

Result:

This new CMS SPI allows Swift Certificates to be used for generating trusted timestamp signatures from CMS structures that embed the signing time, such as those for codesigning.

We have been using this exact same code in a high-volume production environment for several months, and can confirm that the CMS structures generated by this are usable for creating valid signatures.