### PR TITLE
Enable Swift 6.3 jobs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,6 +21,7 @@ jobs:
       linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
+      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
 

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 5831000
+}

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 6379000
+}

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 6387000
+}

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray.append.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray.append.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 10000
+}

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 0
+}

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Verifier.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Verifier.p90.json
@@ -1,0 +1,3 @@
+{
+  "mallocCountTotal" : 810012
+}


### PR DESCRIPTION
Motivation:

Swift 6.3 has been released, we should add it to our CI coverage.

Modifications:

Add additional Swift 6.3 jobs where appropriate in main.yml, pull_request.yml

Result:

Improved test coverage.
