### PR TITLE
Drop Swift 6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -18,7 +18,6 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_6_0_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_1_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors --explicit-target-dependency-import-check error -Xswiftc -require-explicit-sendable"

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 5831000
-}

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 6379000
-}

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 6387000
-}

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.TinyArray.append.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.TinyArray.append.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 10000
-}

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.TinyArray_non-allocating_functions.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 0
-}

--- a/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Verifier.p90.json
+++ b/Benchmarks/Thresholds/6.0/CertificatesBenchmark.Verifier.p90.json
@@ -1,3 +1,0 @@
-{
-  "mallocCountTotal" : 810012
-}

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.0
+// swift-tools-version:6.1
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCertificates open source project


### PR DESCRIPTION
Motivation:

Swift 6.0 is no longer supported, we should bump the tools version and remove it from our CI.

Modifications:

* Bump the Swift tools version to Swift 6.1
* Remove Swift 6.0 jobs where appropriate in main.yml, pull_request.yml

Result:

Code reflects our support window.
