### PR TITLE
 Fix typo in SignatureAlgorithm error message.

### DIFF
--- a/Sources/X509/SignatureAlgorithm.swift
+++ b/Sources/X509/SignatureAlgorithm.swift
@@ -177,7 +177,7 @@ extension Certificate.SignatureAlgorithm {
                 return 0x0807
             default:
                 throw CertificateError.unsupportedSignatureAlgorithm(
-                    reason: "SignatureAlgorithm(\(self)) has an unsupprted value"
+                    reason: "SignatureAlgorithm(\(self)) has an unsupported value"
                 )
             }
         }


### PR DESCRIPTION
 ## Summary
  - Fixed typo in `SignatureAlgorithm.swift:180`: "unsupprted" → "unsupported"

  ## Details
  The error message thrown when an unsupported signature algorithm value is encountered contained a spelling error. This has been corrected.

  ## Test plan
  - Existing tests continue to pass
  - The error message is only shown when an invalid algorithm is used, so no new tests are needed