### PR TITLE
Use sha512UsingNil for the SHA-512 case in OCSPCertID normalization

### DIFF
--- a/Sources/X509/OCSP/OCSPCertID.swift
+++ b/Sources/X509/OCSP/OCSPCertID.swift
@@ -65,7 +65,7 @@ struct OCSPCertID: DERImplicitlyTaggable, Hashable {
                     return .sha256UsingNil
                 case .sha384, .sha384UsingNil:
                     return .sha384UsingNil
-                case .sha512, .sha1UsingNil:
+                case .sha512, .sha512UsingNil:
                     return .sha512UsingNil
                 default:
                     return hashAlgorithm


### PR DESCRIPTION
The `init(derEncoded:withIdentifier:)` normalization in `OCSPCertID` rewrites a decoded hash `AlgorithmIdentifier` to its canonical form so that a decoded response CertID compares equal to the request CertID. The SHA-1, SHA-256, and SHA-384 cases each pair the bare OID with its explicit-NULL-parameters form and return the canonical value, but the SHA-512 case lists `.sha1UsingNil` instead of `.sha512UsingNil`:

```swift
case .sha512, .sha1UsingNil:
    return .sha512UsingNil
```

`.sha1UsingNil` is already matched by the SHA-1 case above, so the explicit-NULL-parameters form of SHA-512 falls through to `default` and is returned unchanged. In practice that path currently yields the same canonical value, so there is no observable difference today, but the case should name `.sha512UsingNil` to match its three siblings and to remain correct if this normalization is extended later.

Resolves #273.
