### PR TITLE
Raise swift-crypto upper version limit

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"6.0.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0"),
     ]
 } else {

--- a/Package.swift
+++ b/Package.swift
@@ -75,7 +75,7 @@ let package = Package(
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"6.0.0"),
+        .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0-beta.max"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0"),
     ]
 } else {


### PR DESCRIPTION
**Motivation:**

Dependencies that depend on the swift-crypto beta version and also want to use swift-certificates run into a dependency resolution conflict. This change allows swift-certificates to use the beta and potential release of the next swift-crypto version.

This is targeting the branch `swift-crypto-5.x`

**Modifications:**

Raise the upper limit of allowed swift-crypto dependencies to `5.0.0-beta.max`, which includes 5.x beta releases.

**Results:**

Enable depending on swift-cryto 5.x beta and swift-certificates.