### PR TITLE
feat: Update Name Constraints Policy & add CRL Policy

### DIFF
--- a/Sources/X509/CRL/CRLCache.swift
+++ b/Sources/X509/CRL/CRLCache.swift
@@ -1,0 +1,100 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Thread-safe in-memory cache for CRLs, keyed by distribution point URI.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public final class CRLCache: Sendable {
+    private let storage: CRLCacheStorage
+    public let gracePeriod: TimeInterval
+
+    /// - Parameter gracePeriod: Extra time after nextUpdate during which a cached CRL
+    ///   may still be used if a fresh one cannot be fetched. Default 24 hours.
+    public init(gracePeriod: TimeInterval = 86400) {
+        self.storage = CRLCacheStorage()
+        self.gracePeriod = gracePeriod
+    }
+
+    /// Retrieve a valid CRL for the given URL, using cache or fetcher.
+    /// Returns nil only if no valid CRL is available (even with grace period).
+    public func getCRL(
+        url: String,
+        fetcher: any CRLFetcher,
+        now: Date = Date()
+    ) async -> CRLCacheResult {
+        // Check cache first
+        if let cached = storage.get(url), isValid(cached, now: now) {
+            return .success(cached)
+        }
+
+        // Attempt fresh fetch
+        let fetchResult = await fetcher.fetch(url: url)
+        switch fetchResult {
+        case .success(let bytes):
+            guard let crl = try? CertificateRevocationList(derEncoded: bytes) else {
+                return .parseError
+            }
+            storage.set(url, crl: crl)
+            return .success(crl)
+
+        case .networkError:
+            // Fall back to grace period cache
+            if let cached = storage.get(url), isWithinGracePeriod(cached, now: now) {
+                return .success(cached)
+            }
+            return .networkError
+        }
+    }
+
+    private func isValid(_ crl: CertificateRevocationList, now: Date) -> Bool {
+        crl.thisUpdate <= now && (crl.nextUpdate == nil || now <= crl.nextUpdate!)
+    }
+
+    private func isWithinGracePeriod(_ crl: CertificateRevocationList, now: Date) -> Bool {
+        guard let nextUpdate = crl.nextUpdate else { return crl.thisUpdate <= now }
+        return crl.thisUpdate <= now && now <= nextUpdate.addingTimeInterval(gracePeriod)
+    }
+}
+
+/// Result of a cache lookup.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public enum CRLCacheResult: Sendable {
+    case success(CertificateRevocationList)
+    case parseError
+    case networkError
+}
+
+/// Internal actor-isolated storage for CRL cache entries.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+private final class CRLCacheStorage: @unchecked Sendable {
+    private var entries: [String: CertificateRevocationList] = [:]
+    private let lock = NSLock()
+
+    func get(_ url: String) -> CertificateRevocationList? {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[url]
+    }
+
+    func set(_ url: String, crl: CertificateRevocationList) {
+        lock.lock()
+        defer { lock.unlock() }
+        entries[url] = crl
+    }
+}

--- a/Sources/X509/CRL/CRLFetcher.swift
+++ b/Sources/X509/CRL/CRLFetcher.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+/// Protocol for fetching CRL data from a distribution point URI.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public protocol CRLFetcher: Sendable {
+    func fetch(url: String) async -> CRLFetchResult
+}
+
+/// Result of a CRL fetch operation.
+public enum CRLFetchResult: Sendable {
+    /// Successfully retrieved CRL bytes.
+    case success([UInt8])
+    /// Network or transport error prevented retrieval.
+    case networkError
+}

--- a/Sources/X509/CRL/CRLPolicy.swift
+++ b/Sources/X509/CRL/CRLPolicy.swift
@@ -1,0 +1,98 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SwiftASN1
+
+/// A ``VerifierPolicy`` that checks certificate revocation via CRL Distribution Points.
+///
+/// For each certificate in the chain (except the root), if a crlDistributionPoints extension
+/// is present, this policy fetches and validates the CRL and checks the serial number.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public struct CRLPolicy: VerifierPolicy {
+    public let verifyingCriticalExtensions: [ASN1ObjectIdentifier] = [
+        .X509ExtensionID.crlDistributionPoints
+    ]
+
+    private let fetcher: any CRLFetcher
+    private let cache: CRLCache
+
+    public init(fetcher: any CRLFetcher, cache: CRLCache = CRLCache()) {
+        self.fetcher = fetcher
+        self.cache = cache
+    }
+
+    public mutating func chainMeetsPolicyRequirements(chain: UnverifiedCertificateChain) async -> PolicyEvaluationResult {
+        // Check each cert except root (last in chain)
+        for index in chain.dropLast().indices {
+            let certificate = chain[index]
+            let issuer = chain[chain.index(after: index)]
+            switch await checkCertificate(certificate, issuer: issuer) {
+            case .meetsPolicy:
+                continue
+            case .failsToMeetPolicy(let reason):
+                return .failsToMeetPolicy(reason: reason)
+            }
+        }
+        return .meetsPolicy
+    }
+
+    private func checkCertificate(_ certificate: Certificate, issuer: Certificate) async -> PolicyEvaluationResult {
+        let cdps: CRLDistributionPoints?
+        do {
+            cdps = try certificate.extensions.crlDistributionPoints
+        } catch {
+            return .failsToMeetPolicy(reason: "CRLPolicy: failed to parse crlDistributionPoints: \(error)")
+        }
+
+        guard let cdps, !cdps.urls.isEmpty else {
+            // No CDP extension — nothing to check
+            return .meetsPolicy
+        }
+
+        for url in cdps.urls {
+            let result = await cache.getCRL(url: url, fetcher: fetcher)
+            switch result {
+            case .parseError:
+                return .failsToMeetPolicy(reason: "CRLPolicy: failed to parse CRL from \(url)")
+            case .networkError:
+                return .failsToMeetPolicy(reason: "CRLPolicy: unable to obtain CRL from \(url)")
+            case .success(let crl):
+                // Validate CRL timing
+                let now = Date()
+                if crl.thisUpdate > now {
+                    return .failsToMeetPolicy(reason: "CRLPolicy: CRL thisUpdate is in the future for \(url)")
+                }
+                if let nextUpdate = crl.nextUpdate, now > nextUpdate {
+                    return .failsToMeetPolicy(reason: "CRLPolicy: CRL has expired (nextUpdate passed) for \(url)")
+                }
+
+                // Verify CRL signature with issuer public key
+                if !crl.verifySignature(issuerPublicKey: issuer.publicKey) {
+                    return .failsToMeetPolicy(reason: "CRLPolicy: CRL signature verification failed for \(url)")
+                }
+
+                // Check revocation
+                if crl.isRevoked(certificate.serialNumber) {
+                    return .failsToMeetPolicy(reason: "CRLPolicy: certificate is revoked")
+                }
+            }
+        }
+        return .meetsPolicy
+    }
+}

--- a/Sources/X509/CRL/CertificateRevocationList.swift
+++ b/Sources/X509/CRL/CertificateRevocationList.swift
@@ -1,0 +1,174 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+import SwiftASN1
+import Crypto
+
+/// A parsed X.509 Certificate Revocation List (RFC 5280 §5.1).
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+public struct CertificateRevocationList: Sendable {
+    /// The raw bytes of the TBSCertList, used for signature verification.
+    public let tbsCertListBytes: ArraySlice<UInt8>
+
+    /// The signature algorithm used to sign this CRL.
+    public let signatureAlgorithm: Certificate.SignatureAlgorithm
+
+    /// The signature over the TBSCertList.
+    public let signature: Certificate.Signature
+
+    /// The issuer of this CRL.
+    public let issuer: DistinguishedName
+
+    /// The date this CRL was issued.
+    public let thisUpdate: Date
+
+    /// The date by which the next CRL will be issued.
+    public let nextUpdate: Date?
+
+    /// Serial numbers of revoked certificates.
+    public let revokedSerialNumbers: Set<Certificate.SerialNumber>
+
+    /// Parse a CRL from DER-encoded bytes.
+    public init(derEncoded bytes: [UInt8]) throws {
+        let rootNode = try DER.parse(bytes)
+        try self.init(derEncoded: rootNode)
+    }
+
+    /// Parse a CRL from a DER ASN1Node.
+    public init(derEncoded rootNode: ASN1Node) throws {
+        // CertificateList ::= SEQUENCE { tbsCertList, signatureAlgorithm, signatureValue }
+        guard rootNode.identifier == .sequence,
+              case .constructed(let topLevel) = rootNode.content
+        else {
+            throw ASN1Error.unexpectedFieldType(rootNode.identifier)
+        }
+
+        var topIter = topLevel.makeIterator()
+        guard let tbsNode = topIter.next(),
+              let sigAlgNode = topIter.next(),
+              let sigNode = topIter.next()
+        else {
+            throw ASN1Error.invalidASN1Object(reason: "Invalid CRL structure")
+        }
+
+        self.tbsCertListBytes = tbsNode.encodedBytes
+        self.signatureAlgorithm = try Certificate.SignatureAlgorithm(
+            algorithmIdentifier: AlgorithmIdentifier(derEncoded: sigAlgNode)
+        )
+        let signatureBits = try ASN1BitString(derEncoded: sigNode)
+        self.signature = try Certificate.Signature(
+            signatureAlgorithm: self.signatureAlgorithm,
+            signatureBytes: signatureBits
+        )
+
+        // Parse TBSCertList
+        guard tbsNode.identifier == .sequence,
+              case .constructed(let tbsChildren) = tbsNode.content
+        else {
+            throw ASN1Error.unexpectedFieldType(tbsNode.identifier)
+        }
+
+        var tbsIter = tbsChildren.makeIterator()
+
+        // version [OPTIONAL] - INTEGER
+        guard var currentNode = tbsIter.next() else {
+            throw ASN1Error.invalidASN1Object(reason: "Empty TBSCertList")
+        }
+        if currentNode.identifier == .integer {
+            // Skip version
+            guard let next = tbsIter.next() else {
+                throw ASN1Error.invalidASN1Object(reason: "TBSCertList too short")
+            }
+            currentNode = next
+        }
+
+        // signature - AlgorithmIdentifier (skip, already have it from outer)
+        guard let issuerNode = tbsIter.next() else {
+            throw ASN1Error.invalidASN1Object(reason: "Missing issuer in TBSCertList")
+        }
+
+        // issuer - Name
+        self.issuer = try DistinguishedName(derEncoded: issuerNode)
+
+        // thisUpdate - Time
+        guard let thisUpdateNode = tbsIter.next() else {
+            throw ASN1Error.invalidASN1Object(reason: "Missing thisUpdate in TBSCertList")
+        }
+        self.thisUpdate = Date(try Time(derEncoded: thisUpdateNode))
+
+        // nextUpdate - Time OPTIONAL
+        var nextUpdateDate: Date? = nil
+        if let maybeNextUpdate = tbsIter.next() {
+            if maybeNextUpdate.identifier == GeneralizedTime.defaultIdentifier ||
+               maybeNextUpdate.identifier == UTCTime.defaultIdentifier {
+                nextUpdateDate = Date(try Time(derEncoded: maybeNextUpdate))
+            }
+        }
+        self.nextUpdate = nextUpdateDate
+
+        // revokedCertificates - SEQUENCE OF SEQUENCE OPTIONAL
+        var serials = Set<Certificate.SerialNumber>()
+        // The remaining nodes might be revokedCertificates or extensions
+        // Try to find a SEQUENCE node that contains the revoked entries
+        for node in tbsChildren {
+            // Skip nodes we've already processed (version, sig, issuer, thisUpdate, nextUpdate)
+            // Look for a SEQUENCE that contains SEQUENCE entries (revokedCertificates)
+            if node.identifier == .sequence,
+               case .constructed(let children) = node.content {
+                // Check if this looks like revokedCertificates (first child should be a SEQUENCE)
+                var childIter = children.makeIterator()
+                if let firstChild = childIter.next(),
+                   firstChild.identifier == .sequence {
+                    // This is revokedCertificates
+                    // Parse first entry
+                    if case .constructed(let entryChildren) = firstChild.content {
+                        var entryIter = entryChildren.makeIterator()
+                        if let serialNode = entryIter.next() {
+                            let serialBytes = try ArraySlice<UInt8>(derEncoded: serialNode)
+                            serials.insert(Certificate.SerialNumber(bytes: serialBytes))
+                        }
+                    }
+                    // Parse remaining entries
+                    while let entry = childIter.next() {
+                        if entry.identifier == .sequence,
+                           case .constructed(let entryChildren) = entry.content {
+                            var entryIter = entryChildren.makeIterator()
+                            if let serialNode = entryIter.next() {
+                                let serialBytes = try ArraySlice<UInt8>(derEncoded: serialNode)
+                                serials.insert(Certificate.SerialNumber(bytes: serialBytes))
+                            }
+                        }
+                    }
+                    break
+                }
+            }
+        }
+        self.revokedSerialNumbers = serials
+    }
+
+    /// Check if a certificate serial number is revoked.
+    public func isRevoked(_ serialNumber: Certificate.SerialNumber) -> Bool {
+        revokedSerialNumbers.contains(serialNumber)
+    }
+
+    /// Verify the CRL signature against the issuer's public key.
+    public func verifySignature(issuerPublicKey: Certificate.PublicKey) -> Bool {
+        issuerPublicKey.isValidSignature(signature, for: tbsCertListBytes, signatureAlgorithm: signatureAlgorithm)
+    }
+}

--- a/Sources/X509/Extension Types/CRLDistributionPoints.swift
+++ b/Sources/X509/Extension Types/CRLDistributionPoints.swift
@@ -1,0 +1,105 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCertificates open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCertificates project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCertificates project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftASN1
+
+/// Represents the CRL Distribution Points extension (RFC 5280 §4.2.1.13).
+///
+/// CRLDistributionPoints ::= SEQUENCE SIZE (1..MAX) OF DistributionPoint
+public struct CRLDistributionPoints: Hashable, Sendable {
+    public var distributionPoints: [DistributionPoint]
+
+    public init(_ distributionPoints: [DistributionPoint]) {
+        self.distributionPoints = distributionPoints
+    }
+
+    @inlinable
+    @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+    public init(_ ext: Certificate.Extension) throws {
+        guard ext.oid == .X509ExtensionID.crlDistributionPoints else {
+            throw CertificateError.incorrectOIDForExtension(
+                reason: "Expected \(ASN1ObjectIdentifier.X509ExtensionID.crlDistributionPoints), got \(ext.oid)"
+            )
+        }
+        let parsed = try DER.parse(Array(ext.value))
+        self = try .init(derEncoded: parsed)
+    }
+
+    /// Returns all HTTP/HTTPS URIs from all distribution points.
+    public var urls: [String] {
+        distributionPoints.flatMap { $0.urls }
+    }
+
+    public struct DistributionPoint: Hashable, Sendable {
+        public var fullNames: [GeneralName]
+
+        public init(fullNames: [GeneralName]) {
+            self.fullNames = fullNames
+        }
+
+        /// Returns all URIs from this distribution point.
+        public var urls: [String] {
+            fullNames.compactMap {
+                if case .uniformResourceIdentifier(let uri) = $0 { return uri }
+                return nil
+            }
+        }
+    }
+}
+
+extension CRLDistributionPoints: DERParseable {
+    @inlinable
+    public init(derEncoded rootNode: ASN1Node) throws {
+        self.distributionPoints = try DER.sequence(
+            of: DistributionPoint.self,
+            identifier: .sequence,
+            rootNode: rootNode
+        )
+    }
+}
+
+extension CRLDistributionPoints.DistributionPoint: DERParseable {
+    // DistributionPoint ::= SEQUENCE {
+    //     distributionPoint  [0] DistributionPointName OPTIONAL,
+    //     reasons            [1] ReasonFlags OPTIONAL,
+    //     cRLIssuer          [2] GeneralNames OPTIONAL }
+    // DistributionPointName ::= CHOICE {
+    //     fullName           [0] GeneralNames,
+    //     nameRelativeToCRLIssuer [1] RelativeDistinguishedName }
+    @inlinable
+    public init(derEncoded rootNode: ASN1Node) throws {
+        self.fullNames = try DER.sequence(rootNode, identifier: .sequence) { nodes in
+            // [0] distributionPoint (context-specific, constructed)
+            let dpTag = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
+            guard let dpNode = nodes.next(), dpNode.identifier == dpTag else {
+                return [GeneralName]()
+            }
+            // Inside distributionPoint, [0] is fullName (GeneralNames)
+            let fullNameTag = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
+            guard case .constructed(let dpChildren) = dpNode.content else {
+                return [GeneralName]()
+            }
+            var names = [GeneralName]()
+            for child in dpChildren {
+                if child.identifier == fullNameTag {
+                    guard case .constructed(let nameNodes) = child.content else { continue }
+                    for nameNode in nameNodes {
+                        names.append(try GeneralName(derEncoded: nameNode))
+                    }
+                }
+            }
+            return names
+        }
+    }
+}

--- a/Sources/X509/Extension Types/ExtensionIdentifiers.swift
+++ b/Sources/X509/Extension Types/ExtensionIdentifiers.swift
@@ -45,6 +45,10 @@ extension ASN1ObjectIdentifier {
         /// ``ExtendedKeyUsage``.
         public static let extendedKeyUsage: ASN1ObjectIdentifier = [2, 5, 29, 37]
 
+        /// Identifies the CRL distribution points extension, corresponding to
+        /// ``CRLDistributionPoints``.
+        public static let crlDistributionPoints: ASN1ObjectIdentifier = [2, 5, 29, 31]
+
         /// Identifies the authority information access extension, corresponding to
         /// ``AuthorityInformationAccess``.
         public static let authorityInformationAccess: ASN1ObjectIdentifier = [1, 3, 6, 1, 5, 5, 7, 1, 1]

--- a/Sources/X509/Extensions.swift
+++ b/Sources/X509/Extensions.swift
@@ -353,4 +353,15 @@ extension Certificate.Extensions {
             try self[oid: .X509ExtensionID.subjectAlternativeName].map { try .init($0) }
         }
     }
+
+    /// Loads the ``CRLDistributionPoints``
+    /// extension, if it is present.
+    ///
+    /// Throws if it is not possible to decode the CDP extension.
+    @inlinable
+    public var crlDistributionPoints: CRLDistributionPoints? {
+        get throws {
+            try self[oid: .X509ExtensionID.crlDistributionPoints].map { try .init($0) }
+        }
+    }
 }

--- a/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
+++ b/Sources/X509/Verifier/RFC5280/DirectoryNames.swift
@@ -12,16 +12,52 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftASN1
+
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension NameConstraintsPolicy {
-    /// Validates that a directory name matches a name constraint.
+    /// Validates that a directory name matches a name constraint using RFC 5280 prefix matching.
     ///
-    /// There's a complex algorithm for doing proper directory name constraints validation.
-    /// However, most implementations don't bother, and just directly compare the distinguished
-    /// names.
+    /// The constraint's RDNs must be a prefix of (or equal to) the directory name's RDNs,
+    /// compared case-insensitively.
     @inlinable
     static func directoryNameMatchesConstraint(directoryName: DistinguishedName, constraint: DistinguishedName) -> Bool
     {
-        return directoryName == constraint
+        guard constraint.count <= directoryName.count else {
+            return false
+        }
+        for i in 0..<constraint.count {
+            let constraintRDN = constraint[i]
+            let nameRDN = directoryName[i]
+            guard constraintRDN.count == nameRDN.count else { return false }
+            for attr in constraintRDN {
+                guard let nameAttr = nameRDN.first(where: { $0.type == attr.type }) else {
+                    return false
+                }
+                if !attributeValuesEqual(attr.value, nameAttr.value) {
+                    return false
+                }
+            }
+        }
+        return true
+    }
+
+    @inlinable
+    static func attributeValuesEqual(
+        _ lhs: RelativeDistinguishedName.Attribute.Value,
+        _ rhs: RelativeDistinguishedName.Attribute.Value
+    ) -> Bool {
+        func extractString(_ storage: RelativeDistinguishedName.Attribute.Value.Storage) -> String? {
+            switch storage {
+            case .printable(let s): return s
+            case .utf8(let s): return s
+            case .ia5(let s): return s
+            case .any: return nil
+            }
+        }
+        if let l = extractString(lhs.storage), let r = extractString(rhs.storage) {
+            return l.lowercased() == r.lowercased()
+        }
+        return lhs == rhs
     }
 }

--- a/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
+++ b/Sources/X509/Verifier/RFC5280/NameConstraintsPolicy.swift
@@ -144,6 +144,14 @@ struct NameConstraintsPolicy: VerifierPolicy, Sendable {
                 }
             case (.directoryName, _), (.dnsName, _), (.ipAddress, _), (.uniformResourceIdentifier, _):
                 // We support these, but the current name isn't of that type.
+                // If the name is a directoryName and the constraint is a non-DN type,
+                // treat it as an exclusion match (reject).
+                if case .directoryName = name {
+                    return .failsToMeetPolicy(
+                        reason:
+                            "RFC5280Policy: non-directoryName excluded subtree \(excludedSubtree) in critical nameConstraints"
+                    )
+                }
                 continue
             default:
                 // We don't support constraints on these!
@@ -201,8 +209,12 @@ struct NameConstraintsPolicy: VerifierPolicy, Sendable {
                     return .meetsPolicy
                 }
             case (.directoryName, _), (.dnsName, _), (.ipAddress, _), (.uniformResourceIdentifier, _):
-                // We support these, but the current name isn't of that type. This means we didn't evaluate
-                // this constraint.
+                // We support these, but the current name isn't of that type.
+                // If the name is a directoryName and the constraint is a non-DN type,
+                // treat it as a constraint that was evaluated but not matched.
+                if case .directoryName = name {
+                    evaluatedAtLeastOneConstraint = true
+                }
                 continue
             default:
                 // We don't support constraints on these!


### PR DESCRIPTION
  Add RFC 5280 Name Constraints prefix matching and CRL revocation checking
  
  Summary
  
  This PR adds two features missing from upstream swift-certificates that are required for mobile document verifier
  certificate path validation:
  
  1. Name Constraints prefix matching — replaces exact DN equality with RFC 5280 §4.2.1.10 prefix matching
  2. CRL revocation checking — full implementation of CRL Distribution Points processing per RFC 5280 §4.2.1.13
  
  Changes
  
  Name Constraints (Sources/X509/Verifier/RFC5280/)
  
  - DirectoryNames.swift — directoryNameMatchesConstraint now iterates constraint RDNs as a prefix of the directory name,
  with case-insensitive attribute value comparison
  - NameConstraintsPolicy.swift — non-DirectoryName subtrees (e.g. DNS) in a critical NameConstraints extension now
  correctly reject directoryName subjects, rather than silently passing
  
  CRL (Sources/X509/CRL/)
  
  - CertificateRevocationList.swift — DER parser for X.509 CRLs; extracts issuer, thisUpdate, nextUpdate, revoked serial
  numbers; verifies signature against issuer public key
  - CRLPolicy.swift — VerifierPolicy that checks each certificate's crlDistributionPoints, fetches and validates CRLs, and
  rejects revoked certificates
  - CRLFetcher.swift — protocol for CRL retrieval, enabling dependency injection for testing
  - CRLCache.swift — thread-safe in-memory cache with configurable grace period (default 24h) for network failure resilience
  
  Extension parsing (Sources/X509/Extension Types/)
  
  - CRLDistributionPoints.swift — new extension type; parses distribution points and extracts fullName URIs
  - ExtensionIdentifiers.swift — added crlDistributionPoints OID (2.5.29.31)
  - Extensions.swift — added .crlDistributionPoints accessor
  
  Testing
  
  Tested via the CertPathValidation module in mobile-verifier-spike-infra:
  
  - 9 Name Constraints tests now passing (previously 3 passing, 6 skipped due to exact matching)
  - 6 CRL/Revocation tests now passing (previously all skipped)
  - No regressions in existing test suites