### PR TITLE
Add env flag to accept swift-crypto beta releases

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -74,9 +74,25 @@ let package = Package(
 // we're building in the Swift.org CI system alongside other projects in the Swift toolchain and
 // we can depend on local versions of our dependencies instead of fetching them remotely.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+
+    // If the `SWIFT_CERTIFICATES_ALLOW_SWIFT_CRYPTO_BETA` environment variable is set
+    // swift-certificates will accept swift-crypto beta releases as a dependency.
+    //
+    // Note: A beta release can only be used if other packages in the dependency tree
+    // that have a direct dependency on swift-crypto accept beta releases as well.
+    if ProcessInfo.processInfo.environment["SWIFT_CERTIFICATES_ALLOW_SWIFT_CRYPTO_BETA"] == nil {
+        package.dependencies += [
+            .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0")
+        ]
+    } else {
+        print("Accepting beta versions of swift-crypto!")
+        package.dependencies += [
+            .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0-beta.max")
+        ]
+    }
+
     package.dependencies += [
-        .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0"),
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.1.0")
     ]
 } else {
     package.dependencies += [


### PR DESCRIPTION
### Motivation

Tagged releases can only have other tagged releases in their dependencies. Tagging a package that depends on a swift-crypto beta and swift-certificates requires a swift-certificates release that accepts a swift-crypto beta release.

### Modifications

Introduce an environment flag that allows swift-certificates to depend on swift-crypto beta releases.

### Results

Setting an environment flag can widen the upper limit of accepted swift-cryto version to include 5.0.0 beta release.