### PR TITLE
Update benchmarks package name and thresholds

### DIFF
--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
     ],
     dependencies: [
         .package(path: "../"),
-        .package(url: "https://github.com/ordo-one/package-benchmark.git", from: "1.11.1"),
+        .package(url: "https://github.com/ordo-one/benchmark.git", from: "1.11.1"),
         .package(url: "https://github.com/apple/swift-crypto.git", "3.12.3"..<"5.0.0"),
         .package(url: "https://github.com/apple/swift-asn1.git", from: "1.0.0"),
     ],
@@ -30,7 +30,7 @@ let package = Package(
         .executableTarget(
             name: "CertificatesBenchmark",
             dependencies: [
-                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Benchmark", package: "benchmark"),
                 .product(name: "X509", package: "swift-certificates"),
                 .product(name: "SwiftASN1", package: "swift-asn1"),
                 .product(name: "Crypto", package: "swift-crypto"),
@@ -40,7 +40,7 @@ let package = Package(
                 .copy("ca-certificates/")
             ],
             plugins: [
-                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+                .plugin(name: "BenchmarkPlugin", package: "benchmark")
             ]
         )
     ]

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_DER.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 5831000
+  "mallocCountTotal" : 5871000
 }

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_PEM_files.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 6379000
+  "mallocCountTotal" : 6419000
 }

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Parse_WebPKI_Roots_from_multi_PEM_file.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 6387000
+  "mallocCountTotal" : 6428000
 }

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray.append.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.TinyArray.append.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 10000
+  "mallocCountTotal" : 9000
 }

--- a/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Verifier.p90.json
+++ b/Benchmarks/Thresholds/6.3/CertificatesBenchmark.Verifier.p90.json
@@ -1,3 +1,3 @@
 {
-  "mallocCountTotal" : 810012
+  "mallocCountTotal" : 810007
 }


### PR DESCRIPTION
### Motivation

The benchmark package got renamed and changed the allocator. Benchmarks thresholds passed with [version 1.34](https://github.com/apple/swift-certificates/actions/runs/28015378822/job/82918309837#step:6:198) and then failed with [version 1.35](https://github.com/apple/swift-certificates/actions/runs/28055879634/job/83057967622#step:6:149).

### Modifications

* Follow benchmark package name change.
* Update failing thresholds.

### Results

6.3 benchmark CI pipeline passes.