### PR TITLE
CMS.isValidAttachedSignature() not using additionalIntermediateCertificates arg

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSOperations.swift
@@ -232,6 +232,7 @@ public enum CMS: Sendable {
             return try await isValidSignature(
                 dataBytes: attachedData.bytes,
                 signatureBytes: signatureBytes,
+                additionalIntermediateCertificates: additionalIntermediateCertificates,
                 trustRoots: trustRoots,
                 diagnosticCallback: diagnosticCallback,
                 microsoftCompatible: microsoftCompatible,

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -1039,6 +1039,26 @@ final class CMSTests: XCTestCase {
         XCTAssertValidSignature(isValidSignature)
     }
 
+    func testCanProvideIntermediatesDuringAttachedVerification() async throws {
+        let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+        let signature = try CMS.sign(
+            data,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            certificate: Self.leaf2Cert,
+            privateKey: Self.leaf2Key,
+            detached: false
+        )
+        let isValidSignature = await CMS.isValidAttachedSignature(
+            signatureBytes: signature,
+            additionalIntermediateCertificates: [Self.intermediateCert],
+            trustRoots: CertificateStore([Self.rootCert])
+        ) {
+            Self.defaultPolicies
+        }
+        XCTAssertValidSignature(isValidSignature)
+    }
+
     func testCanProvideIntermediatesInSigningProcess() async throws {
         let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
 


### PR DESCRIPTION
### Motivation:

`CMS.isValidAttachedSignature()` accepts `additionalIntermediateCertificates[]` but doesn't pass it along to `.isValidSignature()`, causing verification of messages with an attached signature to fail if it contains intermediate cert(s).

### Modifications:

* Pass `additionalIntermediateCertificates[]` arg in `CMS.isValidAttachedSignature()` onto `.isValidSignature()`
* Added `CMSTests.testCanProvideIntermediatesDuringAttachedVerification()` test case (demonstrating the fix)

### Result:

CMS messages with attached signatures containing intermediate certs will now pass verification via `CMS.isValidAttachedSignature()`