### PR TITLE
Allow decoding of v3 CMS SignedData payloads

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignature.swift
@@ -59,7 +59,7 @@ extension CMSSignature: DERImplicitlyTaggable, BERImplicitlyTaggable {
     @inlinable
     public init(derEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard let base = try CMSContentInfo(derEncoded: rootNode, withIdentifier: identifier).signedData,
-            base.version == .v1 || base.version == .v4
+            [CMSVersion.v1, .v3, .v4].contains(base.version)
         else {
             throw CMS.Error.unexpectedCMSType
         }
@@ -70,7 +70,7 @@ extension CMSSignature: DERImplicitlyTaggable, BERImplicitlyTaggable {
     @inlinable
     public init(berEncoded rootNode: ASN1Node, withIdentifier identifier: ASN1Identifier) throws {
         guard let base = try CMSContentInfo(berEncoded: rootNode, withIdentifier: identifier).signedData,
-            base.version == .v1 || base.version == .v4
+            [CMSVersion.v1, .v3, .v4].contains(base.version)
         else {
             throw CMS.Error.unexpectedCMSType
         }

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -561,7 +561,7 @@ final class CMSTests: XCTestCase {
         XCTAssertEqual(try cmsData.encodedBytes, try signature.encodedBytes)
     }
 
-    func testRequireCMSV1SignatureOnCMSSignatureType() async throws {
+    func testRequireValidCMSVersionOnCMSSignatureType() async throws {
         let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         var cmsData = try CMS.generateSignedTestData(
             data,
@@ -570,9 +570,9 @@ final class CMSTests: XCTestCase {
             privateKey: Self.leaf1Key
         )
 
-        // Change the version number to v3
+        // Change the version number to v2, which is not a valid SignedData version
         var signedData = try CMSSignedData(asn1Any: cmsData.content)
-        signedData.version = .v3
+        signedData.version = .v2
         cmsData.content = try ASN1Any(erasing: signedData)
 
         XCTAssertThrowsError(try CMSSignature(derEncoded: cmsData.encodedBytes))
@@ -759,6 +759,26 @@ final class CMSTests: XCTestCase {
             trustRoots: CertificateStore([Self.rootCert])
         ) {}
         XCTAssertUnableToValidateSigner(isValidSignature)
+    }
+    func testCMSV3SignatureWithV3SignerInfo() async throws {
+        let data: [UInt8] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+        let cmsData = try CMS.generateV3SignedTestData(
+            data,
+            signatureAlgorithm: .ecdsaWithSHA256,
+            certificate: Self.leaf1Cert,
+            privateKey: Self.leaf1Key
+        )
+
+        XCTAssertNoThrow(try CMSSignature(derEncoded: cmsData.encodedBytes))
+
+        let isValidSignature = try await CMS.isValidSignature(
+            dataBytes: data,
+            signatureBytes: cmsData.encodedBytes,
+            trustRoots: CertificateStore([Self.rootCert])
+        ) {
+            Self.defaultPolicies
+        }
+        XCTAssertValidSignature(isValidSignature)
     }
 
     func testCMSV4SignatureWithV3SignerInfo() async throws {
@@ -1451,6 +1471,40 @@ extension CMS {
             certificate: certificate,
             withContent: detached ? nil : bytes
         )
+    }
+    static func generateV3SignedTestData<Bytes: DataProtocol>(
+        _ bytes: Bytes,
+        signatureAlgorithm: Certificate.SignatureAlgorithm,
+        additionalIntermediateCertificates: [Certificate] = [],
+        certificate: Certificate,
+        privateKey: Certificate.PrivateKey,
+        detached: Bool = true
+    ) throws -> CMSContentInfo {
+        let signature = try privateKey.sign(bytes: bytes, signatureAlgorithm: signatureAlgorithm)
+        let digestAlgorithm = try AlgorithmIdentifier(digestAlgorithmFor: signatureAlgorithm)
+        var contentInfo = CMSEncapsulatedContentInfo(eContentType: .cmsData)
+        if !detached {
+            contentInfo.eContent = ASN1OctetString(contentBytes: Array(bytes)[...])
+        }
+
+        let signerInfo = CMSSignerInfo(
+            signerIdentifier: .subjectKeyIdentifier(try certificate.extensions.subjectKeyIdentifier!),
+            digestAlgorithm: digestAlgorithm,
+            signatureAlgorithm: AlgorithmIdentifier(signatureAlgorithm),
+            signature: ASN1OctetString(signature)
+        )
+
+        var certificates = additionalIntermediateCertificates
+        certificates.append(certificate)
+
+        let signedData = CMSSignedData(
+            version: .v3,
+            digestAlgorithms: [digestAlgorithm],
+            encapContentInfo: contentInfo,
+            certificates: certificates,
+            signerInfos: [signerInfo]
+        )
+        return try CMSContentInfo(signedData)
     }
     static func generateInvalidSignedTestDataWithSignedAttrs<Bytes: DataProtocol>(
         _ bytes: Bytes,


### PR DESCRIPTION
### Motivation:

`CMSSignature` DER/BER decoding gates v3 SignedData payloads, instead reporting it as `.unexpectedCMSType` .  **v1**, **v3**, and **v4** are all valid versions (**v2** is not defined; **v5** are for CRLs; ref RFC5652 sec 5.1).

While **swift-certificates** does not (currently) support creation of **v3** type messages (although may use Certificates with **v1** attributes), it may encounter CMS payloads generated by other platforms (such as `MessageSecurity.framework`).

### Modifications:

This patch simply adds `.v3` to the guard of supported versions (alongside existing `.v1` and `.v4`). A test case was added (admittedly using a synthesized payload), as well as fix up an existing negative assertion test that used .v3 as an "invalid" version.

If appropriate, could otherwise furnish a CMS message generated by other means to use as a test case (as **swift-certificates** does not support generating one via "natural selection").

### Result:

CMS SignedData **v3** payloads can now be decoded from a DER (and BER) representation.