### PR TITLE
Fix unsignedAttrs inner tag in CMSSignerInfo parsers

### DIFF
--- a/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
+++ b/Sources/X509/CryptographicMessageSyntax/CMSSignerInfo.swift
@@ -137,7 +137,7 @@ struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Se
                 node in
                 return try DER.set(
                     of: CMSAttribute.self,
-                    identifier: .init(tagWithNumber: 0, tagClass: .contextSpecific),
+                    identifier: .init(tagWithNumber: 1, tagClass: .contextSpecific),
                     rootNode: node
                 )
             }
@@ -192,7 +192,7 @@ struct CMSSignerInfo: DERImplicitlyTaggable, BERImplicitlyTaggable, Hashable, Se
                 node in
                 return try BER.set(
                     of: CMSAttribute.self,
-                    identifier: .init(tagWithNumber: 0, tagClass: .contextSpecific),
+                    identifier: .init(tagWithNumber: 1, tagClass: .contextSpecific),
                     rootNode: node
                 )
             }

--- a/Tests/X509Tests/CMSTests.swift
+++ b/Tests/X509Tests/CMSTests.swift
@@ -280,6 +280,44 @@ final class CMSTests: XCTestCase {
             "unexpected signerIdentifier for version should throw"
         )
     }
+    func testCMSSignerInfoWithSignedAndUnsignedAttrsRoundTrips() throws {
+        // unsignedAttrs is serialized as [1] IMPLICIT SET OF Attribute, exercising a tag that
+        // the signedAttrs ([0] IMPLICIT) round trips do not cover.
+        let contentTypeVal = try ASN1Any(erasing: ASN1ObjectIdentifier.cmsData)
+        let attribute = CMSAttribute(attrType: .contentType, attrValues: [contentTypeVal])
+
+        try assertRoundTrips(
+            CMSSignerInfo(
+                version: .v1,
+                signerIdentifier: .issuerAndSerialNumber(
+                    .init(
+                        issuer: .init {
+                            CountryName("US")
+                            OrganizationName("Apple Inc.")
+                            CommonName("Apple Public EV Server ECC CA 1 - G1")
+                        },
+                        serialNumber: .init(bytes: [20, 30, 40, 50])
+                    )
+                ),
+                digestAlgorithm: .sha256WithRSAEncryptionUsingNil,
+                signatureAlgorithm: .ecdsaWithSHA256,
+                signature: .init(contentBytes: [100, 110, 120, 130, 140]),
+                unsignedAttrs: [attribute]
+            )
+        )
+
+        try assertRoundTrips(
+            CMSSignerInfo(
+                version: .v3,
+                signerIdentifier: .subjectKeyIdentifier(.init(keyIdentifier: [10, 20, 30, 40])),
+                digestAlgorithm: .sha256WithRSAEncryptionUsingNil,
+                signedAttrs: [attribute],
+                signatureAlgorithm: .ecdsaWithSHA256,
+                signature: .init(contentBytes: [100, 110, 120, 130, 140]),
+                unsignedAttrs: [attribute]
+            )
+        )
+    }
     func testEncapsulatedContentInfo() throws {
         try assertRoundTrips(
             CMSEncapsulatedContentInfo(


### PR DESCRIPTION
Fixes #306.

### Motivation

`CMSSignerInfo` serializes `unsignedAttrs` as `[1] IMPLICIT SET OF Attribute` per RFC 5652 §5.3, but both the DER and BER parsers — after correctly locating the `[1]`-tagged node via `optionalImplicitlyTagged(tagNumber: 1)` — pass `tagWithNumber: 0` as the inner identifier to `DER.set`/`BER.set` (an apparent copy-paste from the `signedAttrs` block, which really is `[0]`). Any `SignerInfo` that carries unsigned attributes (e.g. a countersignature or RFC 3161 timestamp) therefore fails to parse with:

```
ASN1Error.unexpectedFieldType: ASN1Identifier(tagNumber: 1, tagClass: contextSpecific)
```

including bytes produced by this library's own serializer, so such a `SignerInfo` cannot round-trip.

### Modifications

- Use `tagWithNumber: 1` for the inner `unsignedAttrs` set identifier in both the DER and BER initializers, matching the serializer.
- Added `testCMSSignerInfoWithSignedAndUnsignedAttrsRoundTrips`, covering `unsignedAttrs` alone and combined with `signedAttrs`. The test fails against the previous parser with exactly the error above, and passes with the fix.

### Result

`SignerInfo` values containing `unsignedAttrs` round-trip correctly. Full test suite passes (577 tests), and the changed files are clean under `swift format lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)