### PR TITLE
Fix copy-pasted pattern in OCSPCertID hash algorithm normalization

### DIFF
--- a/Sources/X509/OCSP/OCSPCertID.swift
+++ b/Sources/X509/OCSP/OCSPCertID.swift
@@ -65,7 +65,7 @@ struct OCSPCertID: DERImplicitlyTaggable, Hashable {
                     return .sha256UsingNil
                 case .sha384, .sha384UsingNil:
                     return .sha384UsingNil
-                case .sha512, .sha1UsingNil:
+                case .sha512, .sha512UsingNil:
                     return .sha512UsingNil
                 default:
                     return hashAlgorithm

--- a/Tests/X509Tests/OCSPTests.swift
+++ b/Tests/X509Tests/OCSPTests.swift
@@ -123,6 +123,35 @@ final class OCSPTests: XCTestCase {
         try self.assertRoundTrips(certID)
     }
 
+    func testCertIDNormalizesHashAlgorithmParameters() throws {
+        // Parsing must normalize the absent-parameters spelling of each supported hash
+        // algorithm to the explicit-NULL-parameters spelling, and leave the latter unchanged.
+        let normalizations: [(AlgorithmIdentifier, AlgorithmIdentifier)] = [
+            (.sha1, .sha1UsingNil),
+            (.sha1UsingNil, .sha1UsingNil),
+            (.sha256, .sha256UsingNil),
+            (.sha256UsingNil, .sha256UsingNil),
+            (.sha384, .sha384UsingNil),
+            (.sha384UsingNil, .sha384UsingNil),
+            (.sha512, .sha512UsingNil),
+            (.sha512UsingNil, .sha512UsingNil),
+        ]
+
+        for (spelling, normalized) in normalizations {
+            let certID = OCSPCertID(
+                hashAlgorithm: spelling,
+                issuerNameHash: ASN1OctetString(contentBytes: [1, 2, 3, 4]),
+                issuerKeyHash: ASN1OctetString(contentBytes: [5, 6, 7, 8]),
+                serialNumber: .init(bytes: [9, 10, 11, 12])
+            )
+
+            var serializer = DER.Serializer()
+            try serializer.serialize(certID)
+            let parsed = try OCSPCertID(derEncoded: serializer.serializedBytes)
+            XCTAssertEqual(parsed.hashAlgorithm, normalized, "\(spelling) should normalize to \(normalized)")
+        }
+    }
+
     func testOCSPCertIDSerialization() throws {
         let certID = OCSPCertID(
             hashAlgorithm: .p256PublicKey,


### PR DESCRIPTION
Fixes #273 (@Lukasa invited a PR there and the reporter never followed up, so picking it up).

### Motivation

The sha512 case of `OCSPCertID`'s hash-algorithm normalization switch reads:

```swift
case .sha512, .sha1UsingNil:
    return .sha512UsingNil
```

The `.sha1UsingNil` pattern is a copy-paste from the sha1 case — and it's dead code, since `.sha1UsingNil` is already matched by `case .sha1, .sha1UsingNil:` above.

To be candid about impact: behavior is accidentally correct today. `.sha512` still hits the first pattern and normalizes properly, and `.sha512UsingNil` falls through to `default`, which returns it unchanged — the same result the intended pattern produces. So this is a correctness-of-intent fix, not a behavior change; the danger was latent (e.g. if the `default` case ever changed).

### Modifications

- `case .sha512, .sha1UsingNil:` → `case .sha512, .sha512UsingNil:`
- Added `testCertIDNormalizesHashAlgorithmParameters`, pinning the absent-parameters → NULL-parameters normalization (and the already-normalized spellings) for all four supported hash algorithms, so the intended mapping is now under test.

### Result

The switch states its intent; normalization behavior for every supported algorithm is covered by tests. Full suite: 578 tests pass; changed files clean under `swift format lint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)